### PR TITLE
Run CI on all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Removes the `branches: [main]` filter from the `pull_request` trigger so that CI runs on **all** pull requests, regardless of their base branch.
- Previously, only PRs targeting `main` would trigger CI, meaning PRs between feature branches (e.g. PR #11) were never validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)