### PR TITLE
Add QtiPackageVersionUpdater to normalise QTI 3.0.1 packages before validation

### DIFF
--- a/src/Package/Filesystem/Zip/QtiPackageVersionUpdater.php
+++ b/src/Package/Filesystem/Zip/QtiPackageVersionUpdater.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Package\Filesystem\Zip;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use Qti3\Package\Filesystem\FileSystemUtils;
+use RuntimeException;
+use ZipArchive;
+
+readonly class QtiPackageVersionUpdater
+{
+    public function __construct(
+        private FileSystemUtils $fileSystemUtils,
+    ) {}
+
+    public function updateVersion(string $zipfilePath): string
+    {
+        $zip = $this->openZipFile($zipfilePath);
+        $manifestContent = $this->extractManifest($zip);
+        $zip->close();
+
+        [$dom, $schemaVersion] = $this->findSchemaVersion($manifestContent);
+        $this->validateAndUpdateVersion($dom, $schemaVersion);
+
+        $newManifestContent = $dom->saveXML();
+        if ($newManifestContent === false) {
+            throw new RuntimeException('Failed to save XML document'); // @codeCoverageIgnore
+        }
+
+        // DOM does not allow changing an element's namespace URI via setAttribute,
+        // so replace any remaining v3p1 namespace URI occurrences in the serialised XML.
+        $newManifestContent = str_replace(
+            'http://www.imsglobal.org/xsd/qti/qtiv3p1/imscp_v1p1',
+            'http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1',
+            $newManifestContent,
+        );
+
+        $tmpFile = $this->createTemporaryCopy($zipfilePath);
+        $this->updateManifestInZip($tmpFile, $newManifestContent);
+
+        return $tmpFile;
+    }
+
+    public function cleanup(string $tmpFile): void
+    {
+        FileSystemUtils::removeFile($tmpFile);
+    }
+
+    private function openZipFile(string $zipfilePath): ZipArchive
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($zipfilePath) !== true) {
+            throw new RuntimeException('Could not open zip file: ' . $zipfilePath);
+        }
+        return $zip;
+    }
+
+    private function extractManifest(ZipArchive $zip): string
+    {
+        $manifestContent = $zip->getFromName('imsmanifest.xml');
+        if ($manifestContent === false) {
+            throw new RuntimeException('imsmanifest.xml not found in zip file');
+        }
+        return $manifestContent;
+    }
+
+    /**
+     * @return array{DOMDocument, DOMNode}
+     */
+    private function findSchemaVersion(string $manifestContent): array
+    {
+        libxml_use_internal_errors(true);
+        $dom = new DOMDocument();
+        if (!$dom->loadXML($manifestContent)) {
+            $errors = libxml_get_errors();
+            libxml_clear_errors();
+            throw new RuntimeException('Failed to load imsmanifest.xml: ' . print_r($errors, true));
+        }
+        libxml_use_internal_errors(false);
+
+        $xpath = new DOMXPath($dom);
+
+        $query = "//*[local-name()='manifest']/*[local-name()='metadata']/*[local-name()='schemaversion' or local-name()='version']";
+        $nodes = $xpath->query($query);
+        if ($nodes === false || $nodes->length === 0) {
+            throw new RuntimeException('schemaversion not found in imsmanifest.xml');
+        }
+        /** @var DOMNode $item */
+        $item = $nodes->item(0);
+
+        return [$dom, $item];
+    }
+
+    private function validateAndUpdateVersion(DOMDocument $dom, DOMNode $schemaVersion): void
+    {
+        $version = $schemaVersion->nodeValue;
+        if ($version === '3.0.1') {
+            $schemaVersion->nodeValue = '3.0.0';
+        } elseif ($version !== '3.0.0') {
+            throw new RuntimeException('Invalid schema version. Expected 3.0.1 or 3.0.0');
+        }
+
+        /** @var DOMElement $manifest */
+        $manifest = $schemaVersion->parentNode?->parentNode;
+
+        // Update xsi:schemaLocation references
+        $schemaLocation = $manifest->getAttribute('xsi:schemaLocation');
+        if ($schemaLocation) {
+            $search = [
+                'qtiv3p1/imscp_v1p1',
+                'imsqti_asiv3p1_v1p0.xsd',
+                'imsqtiv3p1_imscpv1p2_v1p0.xsd',
+            ];
+            $replace = [
+                'qtiv3p0/imscp_v1p1',
+                'imsqti_asiv3p0_v1p0.xsd',
+                'imsqtiv3p0_imscpv1p2_v1p0.xsd',
+            ];
+            $schemaLocation = str_replace($search, $replace, $schemaLocation);
+            $manifest->setAttribute('xsi:schemaLocation', $schemaLocation);
+        }
+
+        // Update resource types
+        $xpath = new DOMXPath($dom);
+        $query = "//*[local-name()='resource']";
+        $resources = $xpath->query($query);
+        if ($resources !== false) {
+            foreach ($resources as $resource) {
+                if ($resource instanceof DOMElement && $resource->hasAttribute('type')) {
+                    $type = $resource->getAttribute('type');
+                    $updatedType = str_replace('v3p1', 'v3p0', $type);
+                    $resource->setAttribute('type', $updatedType);
+                }
+            }
+        }
+    }
+
+    private function createTemporaryCopy(string $zipfilePath): string
+    {
+        $tempFilename = $this->fileSystemUtils->generateTempFilename();
+        $tmpFile = $tempFilename . '.zip';
+        FileSystemUtils::removeFile($tempFilename);
+        if (!copy($zipfilePath, $tmpFile)) {
+            throw new RuntimeException('Failed to create temporary copy of zip file'); // @codeCoverageIgnore
+        }
+        return $tmpFile;
+    }
+
+    private function updateManifestInZip(string $tmpFile, string $manifestContent): void
+    {
+        $newZip = new ZipArchive();
+        if ($newZip->open($tmpFile) !== true) {
+            throw new RuntimeException('Could not open new zip file: ' . $tmpFile); // @codeCoverageIgnore
+        }
+        $newZip->deleteName('imsmanifest.xml');
+        if ($newZip->addFromString('imsmanifest.xml', $manifestContent) === false) {
+            throw new RuntimeException('Failed to add updated imsmanifest.xml to zip file'); // @codeCoverageIgnore
+        }
+        $newZip->close();
+    }
+}

--- a/src/Package/Filesystem/Zip/QtiPackageVersionUpdater.php
+++ b/src/Package/Filesystem/Zip/QtiPackageVersionUpdater.php
@@ -157,10 +157,13 @@ readonly class QtiPackageVersionUpdater
         if ($newZip->open($tmpFile) !== true) {
             throw new RuntimeException('Could not open new zip file: ' . $tmpFile); // @codeCoverageIgnore
         }
-        $newZip->deleteName('imsmanifest.xml');
-        if ($newZip->addFromString('imsmanifest.xml', $manifestContent) === false) {
-            throw new RuntimeException('Failed to add updated imsmanifest.xml to zip file'); // @codeCoverageIgnore
+        try {
+            $newZip->deleteName('imsmanifest.xml');
+            if ($newZip->addFromString('imsmanifest.xml', $manifestContent) === false) {
+                throw new RuntimeException('Failed to add updated imsmanifest.xml to zip file'); // @codeCoverageIgnore
+            }
+        } finally {
+            $newZip->close();
         }
-        $newZip->close();
     }
 }

--- a/src/Package/Validator/ImsGlobalQtiSyntaxValidator.php
+++ b/src/Package/Validator/ImsGlobalQtiSyntaxValidator.php
@@ -9,6 +9,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Qti3\Package\Filesystem\FileSystemUtils;
+use Qti3\Package\Filesystem\Zip\QtiPackageVersionUpdater;
 use Qti3\Package\Filesystem\Zip\ZipPackageFactory;
 use Qti3\Package\Model\QtiPackage;
 use Qti3\Shared\Collection\StringCollection;
@@ -37,6 +38,7 @@ use Qti3\Shared\Collection\StringCollection;
  *           $streamFactory,
  *           new ZipPackageFactory(new ZipArchiveFactory(), new FileSystemUtils()),
  *           'http://localhost:8080/api/validate',
+ *           new QtiPackageVersionUpdater(new FileSystemUtils()),
  *       ),
  *   );
  */
@@ -50,6 +52,7 @@ final class ImsGlobalQtiSyntaxValidator implements IQtiSyntaxValidator
         private readonly StreamFactoryInterface $streamFactory,
         private readonly ZipPackageFactory $zipPackageFactory,
         private readonly string $endpointUrl,
+        private readonly QtiPackageVersionUpdater $versionUpdater,
     ) {}
 
     /**
@@ -61,6 +64,17 @@ final class ImsGlobalQtiSyntaxValidator implements IQtiSyntaxValidator
             return new StringCollection(['Package file does not exist: ' . $qtiPackageFilename]);
         }
 
+        $normalised = $this->versionUpdater->updateVersion($qtiPackageFilename);
+
+        try {
+            return $this->doValidateZipPackage($normalised);
+        } finally {
+            $this->versionUpdater->cleanup($normalised);
+        }
+    }
+
+    private function doValidateZipPackage(string $qtiPackageFilename): StringCollection
+    {
         $boundary = bin2hex(random_bytes(16));
         $filename = basename($qtiPackageFilename);
         $fileContents = file_get_contents($qtiPackageFilename);

--- a/src/Package/Validator/QtiSchemaValidator.php
+++ b/src/Package/Validator/QtiSchemaValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Qti3\Package\Validator;
 
 use DOMDocument;
+use Qti3\Package\Filesystem\Zip\QtiPackageVersionUpdater;
 use Qti3\Package\Model\Manifest\Manifest;
 use Qti3\Package\Model\Manifest\ManifestFactory;
 use Qti3\Package\Model\Manifest\ManifestResource;
@@ -30,6 +31,7 @@ readonly class QtiSchemaValidator implements IQtiSyntaxValidator
     public function __construct(
         private ManifestFactory $manifestFactory,
         private IXmlReader $xmlReader,
+        private QtiPackageVersionUpdater $versionUpdater,
     ) {}
 
     public function validateZipPackage(string $qtiPackageFilename): StringCollection
@@ -40,6 +42,19 @@ readonly class QtiSchemaValidator implements IQtiSyntaxValidator
             $errors->add('Package file does not exist: ' . $qtiPackageFilename);
             return $errors;
         }
+
+        $normalised = $this->versionUpdater->updateVersion($qtiPackageFilename);
+
+        try {
+            return $this->doValidateZipPackage($normalised);
+        } finally {
+            $this->versionUpdater->cleanup($normalised);
+        }
+    }
+
+    private function doValidateZipPackage(string $qtiPackageFilename): StringCollection
+    {
+        $errors = new StringCollection();
 
         $zip = new ZipArchive();
         $result = $zip->open($qtiPackageFilename, ZipArchive::RDONLY);

--- a/src/QtiClient.php
+++ b/src/QtiClient.php
@@ -26,6 +26,7 @@ use Qti3\AssessmentTest\Service\TestBuilder;
 use Qti3\Package\Filesystem\FileSystemUtils;
 use Qti3\Package\Filesystem\Zip\ZipArchiveFactory;
 use Qti3\Package\Filesystem\Zip\ZipPackageFactory;
+use Qti3\Package\Filesystem\Zip\QtiPackageVersionUpdater;
 use Qti3\Package\Model\Manifest\ManifestFactory;
 use Qti3\Package\Service\IFilesystemPackageFactory;
 use Qti3\Package\Downloader\Resource\IResourceDownloader;
@@ -63,6 +64,7 @@ final class QtiClient
     private ?TestResourceBuilder $testResourceBuilder = null;
     private ?ItemResourceBuilder $itemResourceBuilder = null;
 
+    private ?QtiPackageVersionUpdater $qtiPackageVersionUpdater = null;
     private ?AssessmentItemParser $assessmentItemParser = null;
     private ?ItemBodyParser $itemBodyParser = null;
     private ?AssessmentTestParser $assessmentTestParser = null;
@@ -144,6 +146,11 @@ final class QtiClient
         );
     }
 
+    public function getQtiPackageVersionUpdater(): QtiPackageVersionUpdater
+    {
+        return $this->qtiPackageVersionUpdater ??= new QtiPackageVersionUpdater(new FileSystemUtils());
+    }
+
     public function getZipPackageFactory(): IZipPackageFactory
     {
         return $this->zipPackageFactory ??= new ZipPackageFactory(
@@ -200,6 +207,7 @@ final class QtiClient
         return $this->qtiSchemaValidator ??= new QtiSchemaValidator(
             $this->getManifestFactory(),
             $this->getXmlReader(),
+            $this->getQtiPackageVersionUpdater(),
         );
     }
 

--- a/tests/Unit/Package/Filesystem/Zip/QtiPackageVersionUpdaterTest.php
+++ b/tests/Unit/Package/Filesystem/Zip/QtiPackageVersionUpdaterTest.php
@@ -229,12 +229,14 @@ class QtiPackageVersionUpdaterTest extends TestCase
         $tmpManifest = tempnam(sys_get_temp_dir(), 'qti_manifest_');
         file_put_contents($tmpManifest, $content);
 
-        $zip = new ZipArchive();
-        $zip->open($tmpZipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
-        $zip->addFile($tmpManifest, 'imsmanifest.xml');
-        $zip->close();
-
-        unlink($tmpManifest);
+        try {
+            $zip = new ZipArchive();
+            $zip->open($tmpZipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+            $zip->addFile($tmpManifest, 'imsmanifest.xml');
+            $zip->close();
+        } finally {
+            unlink($tmpManifest);
+        }
 
         return $tmpZipPath;
     }

--- a/tests/Unit/Package/Filesystem/Zip/QtiPackageVersionUpdaterTest.php
+++ b/tests/Unit/Package/Filesystem/Zip/QtiPackageVersionUpdaterTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Tests\Unit\Package\Filesystem\Zip;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qti3\Package\Filesystem\FileSystemUtils;
+use Qti3\Package\Filesystem\Zip\QtiPackageVersionUpdater;
+use RuntimeException;
+use ZipArchive;
+
+class QtiPackageVersionUpdaterTest extends TestCase
+{
+    private FileSystemUtils&MockObject $fileSystemUtils;
+    private QtiPackageVersionUpdater $updater;
+
+    protected function setUp(): void
+    {
+        $this->fileSystemUtils = $this->createMock(FileSystemUtils::class);
+        $this->updater = new QtiPackageVersionUpdater($this->fileSystemUtils);
+    }
+
+    #[Test]
+    public function updateVersionDowngradesSchemaVersionFrom301To300(): void
+    {
+        $zipFilePath = $this->createZip(__DIR__ . '/fixtures/imsmanifest_v3p1.xml');
+
+        try {
+            $tmpFilePath = '/tmp/qti_test_' . uniqid();
+            $this->fileSystemUtils->expects($this->once())
+                ->method('generateTempFilename')
+                ->willReturn($tmpFilePath);
+
+            $result = $this->updater->updateVersion($zipFilePath);
+
+            $this->assertEquals($tmpFilePath . '.zip', $result);
+
+            $zip = new ZipArchive();
+            $zip->open($result);
+            $manifestContent = $zip->getFromName('imsmanifest.xml');
+            $zip->close();
+
+            $this->assertIsString($manifestContent);
+            $this->assertStringContainsString('3.0.0', $manifestContent);
+            $this->assertStringNotContainsString('3.0.1', $manifestContent);
+        } finally {
+            if (isset($zipFilePath) && file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+            if (isset($result) && file_exists($result)) {
+                unlink($result);
+            }
+        }
+    }
+
+    #[Test]
+    public function updateVersionReplacesV3p1NamespacesWithV3p0(): void
+    {
+        $zipFilePath = $this->createZip(__DIR__ . '/fixtures/imsmanifest_v3p1.xml');
+
+        try {
+            $tmpFilePath = '/tmp/qti_test_' . uniqid();
+            $this->fileSystemUtils->expects($this->once())
+                ->method('generateTempFilename')
+                ->willReturn($tmpFilePath);
+
+            $result = $this->updater->updateVersion($zipFilePath);
+
+            $zip = new ZipArchive();
+            $zip->open($result);
+            $manifestContent = $zip->getFromName('imsmanifest.xml');
+            $zip->close();
+
+            $this->assertIsString($manifestContent);
+            $this->assertStringContainsString('qtiv3p0/imscp_v1p1', $manifestContent);
+            $this->assertStringContainsString('imsqti_asiv3p0_v1p0.xsd', $manifestContent);
+            $this->assertStringContainsString('imsqtiv3p0_imscpv1p2_v1p0.xsd', $manifestContent);
+            $this->assertStringContainsString('imsqti_item_xmlv3p0', $manifestContent);
+            $this->assertStringNotContainsString('v3p1', $manifestContent);
+        } finally {
+            if (isset($zipFilePath) && file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+            if (isset($result) && file_exists($result)) {
+                unlink($result);
+            }
+        }
+    }
+
+    #[Test]
+    public function updateVersionLeavesPackageWithVersion300Unchanged(): void
+    {
+        $manifestXml = '<manifest xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1" identifier="M-001">'
+            . '<metadata><schema>QTI Package</schema><schemaversion>3.0.0</schemaversion></metadata>'
+            . '<organizations/><resources/></manifest>';
+        $zipFilePath = $this->createZipWithContent($manifestXml);
+
+        try {
+            $tmpFilePath = '/tmp/qti_test_' . uniqid();
+            $this->fileSystemUtils->expects($this->once())
+                ->method('generateTempFilename')
+                ->willReturn($tmpFilePath);
+
+            $result = $this->updater->updateVersion($zipFilePath);
+
+            $zip = new ZipArchive();
+            $zip->open($result);
+            $manifestContent = $zip->getFromName('imsmanifest.xml');
+            $zip->close();
+
+            $this->assertIsString($manifestContent);
+            $this->assertStringContainsString('3.0.0', $manifestContent);
+        } finally {
+            if (isset($zipFilePath) && file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+            if (isset($result) && file_exists($result)) {
+                unlink($result);
+            }
+        }
+    }
+
+    #[Test]
+    public function cleanupRemovesTemporaryFile(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'qti_cleanup_test_') . '.zip';
+        touch($tmpFile);
+        $this->assertFileExists($tmpFile);
+
+        $this->updater->cleanup($tmpFile);
+
+        $this->assertFileDoesNotExist($tmpFile);
+    }
+
+    #[Test]
+    public function updateVersionThrowsExceptionForInvalidZipFile(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not open zip file: /invalid/path/to/file.zip');
+
+        $this->updater->updateVersion('/invalid/path/to/file.zip');
+    }
+
+    #[Test]
+    public function updateVersionThrowsExceptionIfManifestNotFound(): void
+    {
+        $zipFilePath = $this->createZipWithoutManifest();
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('imsmanifest.xml not found in zip file');
+
+            $this->updater->updateVersion($zipFilePath);
+        } finally {
+            if (file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function updateVersionThrowsExceptionForInvalidXml(): void
+    {
+        $zipFilePath = $this->createZipWithContent('<invalid-xml><metadata></metadata>');
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Failed to load imsmanifest.xml');
+
+            $this->updater->updateVersion($zipFilePath);
+        } finally {
+            if (file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function updateVersionThrowsExceptionIfSchemaVersionNotFound(): void
+    {
+        $zipFilePath = $this->createZipWithContent('<manifest><metadata></metadata></manifest>');
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('schemaversion not found in imsmanifest.xml');
+
+            $this->updater->updateVersion($zipFilePath);
+        } finally {
+            if (file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function updateVersionThrowsExceptionForUnsupportedSchemaVersion(): void
+    {
+        $xml = '<manifest><metadata><schemaversion>2.0.0</schemaversion></metadata></manifest>';
+        $zipFilePath = $this->createZipWithContent($xml);
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Invalid schema version. Expected 3.0.1 or 3.0.0');
+
+            $this->updater->updateVersion($zipFilePath);
+        } finally {
+            if (file_exists($zipFilePath)) {
+                unlink($zipFilePath);
+            }
+        }
+    }
+
+    private function createZipWithoutManifest(): string
+    {
+        $tmpZipPath = tempnam(sys_get_temp_dir(), 'qti_empty_') . '.zip';
+        $zip = new ZipArchive();
+        $zip->open($tmpZipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('empty.txt', '');
+        $zip->close();
+        return $tmpZipPath;
+    }
+
+    private function createZipWithContent(string $content): string
+    {
+        $tmpZipPath = tempnam(sys_get_temp_dir(), 'qti_content_') . '.zip';
+        $tmpManifest = tempnam(sys_get_temp_dir(), 'qti_manifest_');
+        file_put_contents($tmpManifest, $content);
+
+        $zip = new ZipArchive();
+        $zip->open($tmpZipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile($tmpManifest, 'imsmanifest.xml');
+        $zip->close();
+
+        unlink($tmpManifest);
+
+        return $tmpZipPath;
+    }
+
+    private function createZip(string $manifestPath): string
+    {
+        $tmpZipPath = tempnam(sys_get_temp_dir(), 'qti_') . '.zip';
+        $zip = new ZipArchive();
+        $zip->open($tmpZipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile($manifestPath, 'imsmanifest.xml');
+        $zip->close();
+        return $tmpZipPath;
+    }
+}

--- a/tests/Unit/Package/Filesystem/Zip/fixtures/imsmanifest_v3p1.xml
+++ b/tests/Unit/Package/Filesystem/Zip/fixtures/imsmanifest_v3p1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<manifest xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p1/imscp_v1p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/qti/qtiv3p1/imscp_v1p1 imsqtiv3p1_imscpv1p2_v1p0.xsd imsqti_asiv3p1_v1p0.xsd" identifier="MANIFEST-001">
+    <metadata>
+        <schema>QTI Package</schema>
+        <schemaversion>3.0.1</schemaversion>
+    </metadata>
+    <organizations/>
+    <resources>
+        <resource identifier="ITEM-001" type="imsqti_item_xmlv3p1" href="item.xml">
+            <file href="item.xml"/>
+        </resource>
+    </resources>
+</manifest>

--- a/tests/Unit/Package/Validator/ImsGlobalQtiSyntaxValidatorTest.php
+++ b/tests/Unit/Package/Validator/ImsGlobalQtiSyntaxValidatorTest.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Qti3\Package\Filesystem\Zip\QtiPackageVersionUpdater;
 use Qti3\Package\Filesystem\Zip\ZipPackageFactory;
 use Qti3\Package\Model\IPackageWriter;
 use Qti3\Package\Validator\ImsGlobalQtiSyntaxValidator;
@@ -24,6 +25,7 @@ class ImsGlobalQtiSyntaxValidatorTest extends TestCase
     private RequestFactoryInterface $requestFactory;
     private StreamFactoryInterface $streamFactory;
     private ZipPackageFactory $zipPackageFactory;
+    private QtiPackageVersionUpdater $versionUpdater;
     private ImsGlobalQtiSyntaxValidator $validator;
 
     protected function setUp(): void
@@ -32,6 +34,8 @@ class ImsGlobalQtiSyntaxValidatorTest extends TestCase
         $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
         $this->streamFactory = $this->createMock(StreamFactoryInterface::class);
         $this->zipPackageFactory = $this->createMock(ZipPackageFactory::class);
+        $this->versionUpdater = $this->createMock(QtiPackageVersionUpdater::class);
+        $this->versionUpdater->method('updateVersion')->willReturnArgument(0);
 
         $request = $this->createMock(RequestInterface::class);
         $request->method('withHeader')->willReturnSelf();
@@ -45,6 +49,7 @@ class ImsGlobalQtiSyntaxValidatorTest extends TestCase
             $this->streamFactory,
             $this->zipPackageFactory,
             'http://localhost:8080/api/validate',
+            $this->versionUpdater,
         );
     }
 

--- a/tests/Unit/Package/Validator/QtiSchemaValidatorTest.php
+++ b/tests/Unit/Package/Validator/QtiSchemaValidatorTest.php
@@ -14,9 +14,11 @@ use Qti3\Package\Model\QtiPackage;
 use Qti3\Package\Model\Resource\Resource;
 use Qti3\Package\Model\Resource\ResourceCollection;
 use Qti3\Package\Model\Resource\ResourceType;
+use Qti3\Package\Filesystem\Zip\QtiPackageVersionUpdater;
 use Qti3\Package\Validator\QtiSchemaValidator;
 use Qti3\Shared\Xml\Reader\XmlReader;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ZipArchive;
 
@@ -25,12 +27,15 @@ class QtiSchemaValidatorTest extends TestCase
     private QtiSchemaValidator $validator;
     private XmlReader $xmlReader;
     private ManifestFactory $manifestFactory;
+    private QtiPackageVersionUpdater&MockObject $versionUpdater;
 
     protected function setUp(): void
     {
         $this->xmlReader = new XmlReader();
         $this->manifestFactory = new ManifestFactory($this->xmlReader);
-        $this->validator = new QtiSchemaValidator($this->manifestFactory, $this->xmlReader);
+        $this->versionUpdater = $this->createMock(QtiPackageVersionUpdater::class);
+        $this->versionUpdater->method('updateVersion')->willReturnArgument(0);
+        $this->validator = new QtiSchemaValidator($this->manifestFactory, $this->xmlReader, $this->versionUpdater);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Adds `QtiPackageVersionUpdater` (`src/Package/Filesystem/Zip/`) that rewrites the manifest of a v3.0.1 package into a temporary ZIP copy compatible with QTI 3.0.0 (v3p0 namespaces, schemaLocation, and resource types)
- Integrates the updater transparently into `validateZipPackage()` of both `QtiSchemaValidator` and `ImsGlobalQtiSyntaxValidator` — callers no longer need to pre-process packages manually
- Exposes the updater via `QtiClient::getQtiPackageVersionUpdater()` for direct use (e.g. before `QtiPackageReader::fromZip()`)

## Background

Packages with `schemaversion 3.0.1` use `v3p1` namespace URIs and resource types (`imsqti_item_xmlv3p1` etc.) that are rejected by both the local XSD validator and the IMS Global Docker validator — both target QTI 3.0.0. This logic was previously only present in the consuming application (`wikiwijs-toetsen`); it now lives in this library where it belongs.

Note: `validate(QtiPackage $package)` does not need this pre-processing — a `QtiPackage` can never be built from a v3.0.1 ZIP in the first place, because `ResourceType` only accepts `v3p0` values and `Manifest::getResources()` throws on unknown types.

## Test plan

- [x] 9 new unit tests for `QtiPackageVersionUpdater` covering: version downgrade, namespace/schemaLocation/resource-type replacement, no-op on already-3.0.0 packages, cleanup, and all error paths
- [x] `QtiSchemaValidator` and `ImsGlobalQtiSyntaxValidator` unit tests updated to mock the updater (pass-through), keeping validator logic isolated
- [x] Full test suite: 537 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)