### PR TITLE
Add removeItem method to IItemEditor

### DIFF
--- a/src/Package/Exception/CannotRemoveLastItemException.php
+++ b/src/Package/Exception/CannotRemoveLastItemException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Package\Exception;
+
+use Qti3\Shared\Exception\DomainError;
+use Qti3\Shared\Exception\ErrorType;
+
+final class CannotRemoveLastItemException extends DomainError
+{
+    public function __construct(
+        private readonly string $identifier,
+    ) {
+        parent::__construct($this->errorMessage());
+    }
+
+    public function errorCode(): string
+    {
+        return 'cannot_remove_last_item';
+    }
+
+    public function errorType(): ErrorType
+    {
+        return ErrorType::VALIDATION;
+    }
+
+    protected function errorMessage(): string
+    {
+        return sprintf('Item %s is the last item in the package and cannot be removed.', $this->identifier);
+    }
+}

--- a/src/Package/Filesystem/FlysystemItemEditor.php
+++ b/src/Package/Filesystem/FlysystemItemEditor.php
@@ -7,6 +7,7 @@ namespace Qti3\Package\Filesystem;
 use DOMDocument;
 use DOMElement;
 use League\Flysystem\FilesystemOperator;
+use Qti3\Package\Exception\CannotRemoveLastItemException;
 use Qti3\Package\Exception\InvalidItemOrderException;
 use Qti3\Package\Exception\InvalidQtiPackageException;
 use Qti3\Package\Model\IItemEditor;
@@ -19,9 +20,9 @@ use Qti3\Shared\Xml\Reader\IXmlReader;
 use RuntimeException;
 
 /**
- * Adds and updates assessment items inside an already extracted QTI package
- * folder, operating directly on the individual files through a
- * {@see FilesystemOperator}.
+ * Adds, updates, reorders and removes assessment items inside an already
+ * extracted QTI package folder, operating directly on the individual files
+ * through a {@see FilesystemOperator}.
  *
  * This is intentionally file-targeted rather than model-based: adding an item
  * touches only the manifest, the assessment test and the new item file, and
@@ -154,6 +155,48 @@ final readonly class FlysystemItemEditor implements IItemEditor
     }
 
     /**
+     * Remove an item: delete its resource entry (plus dependency references)
+     * from the manifest, its item ref from the assessment test, the item file
+     * itself, and any files no longer referenced by the remaining resources.
+     */
+    public function removeItem(string $identifier): void
+    {
+        // Read and patch everything in memory first, so a structural problem
+        // aborts before any file is written.
+        $manifest = $this->readXml($this->base . self::MANIFEST_FILE);
+
+        $itemResource = $this->itemResource($manifest, $identifier);
+        if ($itemResource === null) {
+            throw new ResourceNotFoundException('AssessmentItem', $identifier);
+        }
+
+        if (count($this->itemResources($manifest)) === 1) {
+            throw new CannotRemoveLastItemException($identifier);
+        }
+
+        $removedHrefs = $this->resourceHrefs($itemResource);
+        $itemResource->parentNode?->removeChild($itemResource);
+        $this->removeDependencyReferences($manifest, $identifier);
+
+        $orphanedFiles = array_values(array_diff($removedHrefs, $this->referencedHrefs($manifest)));
+
+        $testHref = $this->testResourceHref($manifest);
+        $test = $this->readXml($this->base . $testHref);
+        $this->removeItemRef($test, $identifier);
+
+        // Only now write, manifest first: if that write fails, nothing else
+        // has been touched yet.
+        $this->filesystem->write($this->base . self::MANIFEST_FILE, $this->save($manifest));
+        $this->filesystem->write($this->base . $testHref, $this->save($test));
+
+        foreach ($orphanedFiles as $orphanedFile) {
+            if ($this->filesystem->fileExists($this->base . $orphanedFile)) {
+                $this->filesystem->delete($this->base . $orphanedFile);
+            }
+        }
+    }
+
+    /**
      * @param list<string> $currentIdentifiers
      * @param list<string> $orderedIdentifiers
      */
@@ -248,6 +291,100 @@ final readonly class FlysystemItemEditor implements IItemEditor
         $itemRef->setAttribute('identifier', $identifier);
         $itemRef->setAttribute('href', $href);
         $section->appendChild($itemRef);
+    }
+
+    private function itemResource(DOMDocument $manifest, string $identifier): ?DOMElement
+    {
+        foreach ($this->itemResources($manifest) as $resource) {
+            if ($resource->getAttribute('identifier') === $identifier) {
+                return $resource;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<DOMElement>
+     */
+    private function itemResources(DOMDocument $manifest): array
+    {
+        $resources = [];
+
+        foreach ($manifest->getElementsByTagNameNS(self::MANIFEST_NAMESPACE, 'resource') as $resource) {
+            if ($resource->getAttribute('type') === self::ITEM_RESOURCE_TYPE) {
+                $resources[] = $resource;
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * All files a resource points at: its own href plus the hrefs of its
+     * <file> children.
+     *
+     * @return list<string>
+     */
+    private function resourceHrefs(DOMElement $resource): array
+    {
+        $hrefs = [];
+
+        if ($resource->getAttribute('href') !== '') {
+            $hrefs[] = $resource->getAttribute('href');
+        }
+
+        foreach ($resource->getElementsByTagNameNS(self::MANIFEST_NAMESPACE, 'file') as $file) {
+            if ($file->getAttribute('href') !== '') {
+                $hrefs[] = $file->getAttribute('href');
+            }
+        }
+
+        return array_values(array_unique($hrefs));
+    }
+
+    private function removeDependencyReferences(DOMDocument $manifest, string $identifier): void
+    {
+        // Collect first: removing while iterating a live DOMNodeList skips nodes.
+        $dependencies = [];
+        foreach ($manifest->getElementsByTagNameNS(self::MANIFEST_NAMESPACE, 'dependency') as $dependency) {
+            if ($dependency->getAttribute('identifierref') === $identifier) {
+                $dependencies[] = $dependency;
+            }
+        }
+
+        foreach ($dependencies as $dependency) {
+            $dependency->parentNode?->removeChild($dependency);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function referencedHrefs(DOMDocument $manifest): array
+    {
+        $hrefs = [];
+
+        foreach ($manifest->getElementsByTagNameNS(self::MANIFEST_NAMESPACE, 'resource') as $resource) {
+            $hrefs = [...$hrefs, ...$this->resourceHrefs($resource)];
+        }
+
+        return array_values(array_unique($hrefs));
+    }
+
+    private function removeItemRef(DOMDocument $test, string $identifier): void
+    {
+        // Collect first: removing while iterating a live DOMNodeList skips nodes.
+        $itemRefs = [];
+        foreach ($test->getElementsByTagNameNS(self::ASI_NAMESPACE, 'qti-assessment-item-ref') as $itemRef) {
+            if ($itemRef->getAttribute('identifier') === $identifier) {
+                $itemRefs[] = $itemRef;
+            }
+        }
+
+        foreach ($itemRefs as $itemRef) {
+            $itemRef->parentNode?->removeChild($itemRef);
+        }
     }
 
     private function normaliseIdentifier(string $itemXml, string $identifier): string

--- a/src/Package/Model/IItemEditor.php
+++ b/src/Package/Model/IItemEditor.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Qti3\Package\Model;
 
+use Qti3\Package\Exception\CannotRemoveLastItemException;
 use Qti3\Package\Model\Item\EditedItem;
+use Qti3\Shared\Exception\ResourceNotFoundException;
 
 /**
- * Adds and updates assessment items inside a single extracted QTI package
- * folder. Obtained per folder from {@see \Qti3\Package\Service\IFilesystemPackageFactory::getItemEditor()},
+ * Adds, updates, reorders and removes assessment items inside a single
+ * extracted QTI package folder. Obtained per folder from
+ * {@see \Qti3\Package\Service\IFilesystemPackageFactory::getItemEditor()},
  * mirroring the reader/writer factory methods.
  */
 interface IItemEditor
@@ -19,4 +22,14 @@ interface IItemEditor
 
     /** @param list<string> $orderedIdentifiers */
     public function reorderItems(array $orderedIdentifiers): void;
+
+    /**
+     * Remove an item: delete its resource entry (plus dependency references)
+     * from the manifest, its item ref from the assessment test, the item file
+     * itself, and any files no longer referenced by the remaining resources.
+     *
+     * @throws ResourceNotFoundException when the item is not in the manifest
+     * @throws CannotRemoveLastItemException when the item is the last item left in the package
+     */
+    public function removeItem(string $identifier): void;
 }

--- a/tests/Unit/Package/Filesystem/FlysystemItemEditorTest.php
+++ b/tests/Unit/Package/Filesystem/FlysystemItemEditorTest.php
@@ -11,6 +11,7 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Qti3\Package\Exception\CannotRemoveLastItemException;
 use Qti3\Package\Exception\InvalidAssessmentItemException;
 use Qti3\Package\Exception\InvalidItemOrderException;
 use Qti3\Package\Exception\InvalidQtiPackageException;
@@ -407,6 +408,152 @@ final class FlysystemItemEditorTest extends TestCase
                 $sectionsXml,
             ),
         );
+    }
+
+    #[Test]
+    public function removeItemDeletesTheItemFile(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+
+        $this->editor->removeItem('ITEM001');
+
+        $this->assertFalse($this->filesystem->fileExists(self::FOLDER . '/ITEM001.xml'));
+        $this->assertTrue($this->filesystem->fileExists(self::FOLDER . '/ITEM002.xml'));
+    }
+
+    #[Test]
+    public function removeItemRemovesTheResourceAndDependencyReferencesFromTheManifest(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+
+        $this->editor->removeItem('ITEM001');
+
+        $manifest = $this->read('imsmanifest.xml');
+        $this->assertStringNotContainsString('ITEM001', $manifest);
+        $this->assertStringContainsString('identifier="ITEM002"', $manifest);
+        $this->assertStringContainsString('<dependency identifierref="ITEM002"/>', $manifest);
+    }
+
+    #[Test]
+    public function removeItemRemovesTheItemRefFromTheAssessmentTest(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+
+        $this->editor->removeItem('ITEM001');
+
+        $test = $this->read('AssessmentTest.xml');
+        $this->assertStringNotContainsString('ITEM001', $test);
+        $this->assertNotNull($this->findElement($test, self::ASI_NAMESPACE, 'qti-assessment-item-ref', 'ITEM002'));
+    }
+
+    #[Test]
+    public function removeItemDeletesAssetsOnlyReferencedByTheRemovedItem(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+
+        $this->editor->removeItem('ITEM001');
+
+        $this->assertFalse($this->filesystem->fileExists(self::FOLDER . '/img/only-item001.png'));
+        $this->assertStringNotContainsString('img/only-item001.png', $this->read('imsmanifest.xml'));
+    }
+
+    #[Test]
+    public function removeItemKeepsAssetsSharedWithOtherItems(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+
+        $this->editor->removeItem('ITEM001');
+
+        $this->assertTrue($this->filesystem->fileExists(self::FOLDER . '/img/shared.png'));
+        $this->assertStringContainsString('img/shared.png', $this->read('imsmanifest.xml'));
+    }
+
+    #[Test]
+    public function removeItemSkipsDeletingOrphanedFilesThatAreAlreadyMissing(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+        $this->filesystem->delete(self::FOLDER . '/img/only-item001.png');
+
+        $this->editor->removeItem('ITEM001');
+
+        $this->assertFalse($this->filesystem->fileExists(self::FOLDER . '/ITEM001.xml'));
+    }
+
+    #[Test]
+    public function removeItemThrowsWhenTheItemDoesNotExist(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+
+        $this->expectException(ResourceNotFoundException::class);
+
+        $this->editor->removeItem('ITEM999');
+    }
+
+    #[Test]
+    public function removeItemRefusesToRemoveTheLastItem(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets();
+        $this->editor->removeItem('ITEM001');
+
+        $this->expectException(CannotRemoveLastItemException::class);
+
+        $this->editor->removeItem('ITEM002');
+    }
+
+    #[Test]
+    public function removeItemWritesNothingWhenTheManifestHasNoAssessmentTestResource(): void
+    {
+        $this->seedDraftWithTwoItemsAndAssets(includeTestResource: false);
+        $manifestBefore = $this->read('imsmanifest.xml');
+
+        try {
+            $this->editor->removeItem('ITEM001');
+            $this->fail('Expected InvalidQtiPackageException');
+        } catch (InvalidQtiPackageException) {
+            // A structural failure must abort before any file is written or deleted.
+            $this->assertSame($manifestBefore, $this->read('imsmanifest.xml'));
+            $this->assertTrue($this->filesystem->fileExists(self::FOLDER . '/ITEM001.xml'));
+            $this->assertTrue($this->filesystem->fileExists(self::FOLDER . '/img/only-item001.png'));
+        }
+    }
+
+    private function seedDraftWithTwoItemsAndAssets(bool $includeTestResource = true): void
+    {
+        $testResource = $includeTestResource
+            ? '<resource identifier="test" type="imsqti_test_xmlv3p0" href="AssessmentTest.xml"><file href="AssessmentTest.xml"/>'
+                . '<dependency identifierref="ITEM001"/><dependency identifierref="ITEM002"/></resource>'
+            : '';
+
+        $manifest = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<manifest xmlns="%s" identifier="MANIFEST-1"><organizations/><resources>'
+            . '%s'
+            . '<resource identifier="ITEM001" type="imsqti_item_xmlv3p0" href="ITEM001.xml">'
+            . '<file href="ITEM001.xml"/><file href="img/only-item001.png"/><file href="img/shared.png"/></resource>'
+            . '<resource identifier="ITEM002" type="imsqti_item_xmlv3p0" href="ITEM002.xml">'
+            . '<file href="ITEM002.xml"/><file href="img/shared.png"/></resource>'
+            . '</resources></manifest>',
+            self::MANIFEST_NAMESPACE,
+            $testResource,
+        );
+
+        $test = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<qti-assessment-test xmlns="%s" identifier="test-1" title="">'
+            . '<qti-test-part identifier="testPart-1" navigation-mode="linear" submission-mode="individual">'
+            . '<qti-assessment-section identifier="section-1" title="" visible="true">'
+            . '<qti-assessment-item-ref identifier="ITEM001" href="ITEM001.xml"/>'
+            . '<qti-assessment-item-ref identifier="ITEM002" href="ITEM002.xml"/>'
+            . '</qti-assessment-section></qti-test-part></qti-assessment-test>',
+            self::ASI_NAMESPACE,
+        );
+
+        $this->filesystem->write(self::FOLDER . '/imsmanifest.xml', $manifest);
+        $this->filesystem->write(self::FOLDER . '/AssessmentTest.xml', $test);
+        $this->filesystem->write(self::FOLDER . '/ITEM001.xml', $this->itemXml('ITEM001'));
+        $this->filesystem->write(self::FOLDER . '/ITEM002.xml', $this->itemXml('ITEM002'));
+        $this->filesystem->write(self::FOLDER . '/img/only-item001.png', 'only-item001-image');
+        $this->filesystem->write(self::FOLDER . '/img/shared.png', 'shared-image');
     }
 
     private function seedEmptyDraft(string $testHref = 'AssessmentTest.xml'): void


### PR DESCRIPTION
- Added `removeItem` method to the `IItemEditor` interface.
- Implemented functionality to handle item deletion along with its dependencies.
- Remove orphaned assets 
