### PR TITLE
Add PackageEditor::addResource for standalone webcontent assets

### DIFF
--- a/docs/package-editor.md
+++ b/docs/package-editor.md
@@ -135,6 +135,34 @@ $parsed = $qtiClient->getAssessmentItemParser()->parseFromString($itemXml);
 $result = $editor->updateItem($package, $parsed->item); // $result->resource is the updated item
 ```
 
+## Adding a resource (e.g. an uploaded file)
+
+`addResource()` adds a standalone `webcontent` asset — an uploaded image, audio
+clip, etc. — to the package, independent of any item. This supports a two-step
+editor flow: the file is uploaded and added first, and the item XML that
+references it arrives in a later request.
+
+```php
+// Request 1: the uploaded bytes are added to the package.
+$result = $editor->addResource($package, 'photo.png', $uploadedBytes);
+$href = $result->resource->href; // e.g. "resources/<md5>.png" — use this in the item XML
+// ...save the package...
+```
+
+The file is stored under `resources/` with a **content-addressed** name (the md5
+of its bytes plus the original extension), so adding identical bytes again is
+idempotent and returns the existing resource instead of a duplicate. Pass
+`isBinary: false` for text-based assets.
+
+```php
+// Request 2: an item update whose XML references $href reuses the resource
+// added earlier — no duplicate resource is created, and the dependency is
+// linked automatically.
+$itemXml = str_replace('{{IMAGE}}', $href, $template);
+$parsed = $qtiClient->getAssessmentItemParser()->parseFromString($itemXml);
+$editor->updateItem($package, $parsed->item);
+```
+
 ## Removing an item
 
 ```php

--- a/docs/package-editor.md
+++ b/docs/package-editor.md
@@ -142,13 +142,17 @@ clip, etc. — to the package, independent of any item. This supports a two-step
 editor flow: the file is uploaded and added first, and the item XML that
 references it arrives in a later request.
 
-You choose the package-relative path the file should live at; it is registered
-as a `webcontent` resource with a fresh `RESOURCEnnn` identifier. Intermediate
-directories in the path are created by the writer when the package is saved.
+You choose the package-relative path the file should live at, and pass the
+content as an `IFileContent` — `MemoryFileContent` for raw bytes, or a
+lazy/streaming implementation. It is registered as a `webcontent` resource with
+a fresh `RESOURCEnnn` identifier. Intermediate directories in the path are
+created by the writer when the package is saved.
 
 ```php
+use Qti3\Package\Model\FileContent\MemoryFileContent;
+
 // Request 1: the uploaded bytes are added to the package at a path you choose.
-$result = $editor->addResource($package, 'resources/photo.png', $uploadedBytes);
+$result = $editor->addResource($package, 'resources/photo.png', new MemoryFileContent($uploadedBytes));
 $href = $result->resource->href; // 'resources/photo.png' — use this in the item XML
 // ...save the package...
 ```

--- a/docs/package-editor.md
+++ b/docs/package-editor.md
@@ -142,17 +142,21 @@ clip, etc. — to the package, independent of any item. This supports a two-step
 editor flow: the file is uploaded and added first, and the item XML that
 references it arrives in a later request.
 
+You choose the package-relative path the file should live at; it is registered
+as a `webcontent` resource with a fresh `RESOURCEnnn` identifier. Intermediate
+directories in the path are created by the writer when the package is saved.
+
 ```php
-// Request 1: the uploaded bytes are added to the package.
-$result = $editor->addResource($package, 'photo.png', $uploadedBytes);
-$href = $result->resource->href; // e.g. "resources/<md5>.png" — use this in the item XML
+// Request 1: the uploaded bytes are added to the package at a path you choose.
+$result = $editor->addResource($package, 'resources/photo.png', $uploadedBytes);
+$href = $result->resource->href; // 'resources/photo.png' — use this in the item XML
 // ...save the package...
 ```
 
-The file is stored under `resources/` with a **content-addressed** name (the md5
-of its bytes plus the original extension), so adding identical bytes again is
-idempotent and returns the existing resource instead of a duplicate. Pass
-`isBinary: false` for text-based assets.
+Pass `isBinary: false` for text-based assets. The path must stay inside the
+package: an absolute path or a `..` segment is rejected, and adding a second
+resource at a path that already exists throws — the caller is responsible for
+choosing a unique path.
 
 ```php
 // Request 2: an item update whose XML references $href reuses the resource

--- a/src/Package/Service/PackageEditor.php
+++ b/src/Package/Service/PackageEditor.php
@@ -17,7 +17,7 @@ use Qti3\AssessmentTest\Model\ItemRef\AssessmentItemRef;
 use Qti3\AssessmentTest\Service\TestBuilder;
 use Qti3\AssessmentTest\Service\TestParseResult;
 use Qti3\Package\Exception\InvalidQtiPackageException;
-use Qti3\Package\Model\FileContent\MemoryFileContent;
+use Qti3\Package\Model\FileContent\IFileContent;
 use Qti3\Package\Model\Manifest\ManifestResourceDependency;
 use Qti3\Package\Model\Manifest\ManifestResourceDependencyCollection;
 use Qti3\Package\Model\PackageFile\XmlFile;
@@ -62,17 +62,19 @@ final readonly class PackageEditor
     /**
      * Add a standalone webcontent asset (e.g. an uploaded image) to the package,
      * independent of any item. The caller supplies the package-relative `$path`
-     * where the file should live (e.g. `resources/pic.png`); intermediate
-     * directories in that path are created by the writer when the package is
-     * saved. The file is registered as a `webcontent` resource with a fresh
-     * `RESOURCEnnn` identifier.
+     * where the file should live (e.g. `resources/pic.png`) and its `$content`
+     * as an {@see IFileContent} (e.g. {@see \Qti3\Package\Model\FileContent\MemoryFileContent}
+     * for raw bytes, or
+     * a lazy/streaming implementation); intermediate directories in the path are
+     * created by the writer when the package is saved. The file is registered as
+     * a `webcontent` resource with a fresh `RESOURCEnnn` identifier.
      *
      * A later {@see self::updateItem()} whose item XML references `$path` reuses
      * this resource rather than re-adding it. Throws when `$path` is absolute or
      * escapes the package (`..`), or when the package already holds a file at
      * `$path`.
      */
-    public function addResource(QtiPackage $package, string $path, string $content, bool $isBinary = true): EditResult
+    public function addResource(QtiPackage $package, string $path, IFileContent $content, bool $isBinary = true): EditResult
     {
         $this->assertValidResourcePath($path);
         if ($this->resourceByHref($package, $path) !== null) {
@@ -83,7 +85,7 @@ final readonly class PackageEditor
             $path,
             $this->webcontentIdentifierGenerator->nextIdentifier($this->resourceIdentifiers($package)),
             $path,
-            new MemoryFileContent($content),
+            $content,
             $isBinary,
         );
         $package->addResource($resource);

--- a/src/Package/Service/PackageEditor.php
+++ b/src/Package/Service/PackageEditor.php
@@ -50,6 +50,7 @@ final readonly class PackageEditor
         private ItemResourceBuilder $itemResourceBuilder,
         private WebcontentProcessor $webcontentProcessor,
         private AssessmentItemParser $assessmentItemParser,
+        private WebcontentIdentifierGenerator $webcontentIdentifierGenerator,
     ) {}
 
     /** Next free item identifier for the package (`ITEMnnn`, package-unique). */
@@ -60,29 +61,28 @@ final readonly class PackageEditor
 
     /**
      * Add a standalone webcontent asset (e.g. an uploaded image) to the package,
-     * independent of any item. The bytes are stored under `resources/` with a
-     * content-addressed name (md5 of the content plus the original extension)
-     * and registered as a `webcontent` resource with a fresh `RESOURCEnnn`
-     * identifier.
+     * independent of any item. The caller supplies the package-relative `$path`
+     * where the file should live (e.g. `resources/pic.png`); intermediate
+     * directories in that path are created by the writer when the package is
+     * saved. The file is registered as a `webcontent` resource with a fresh
+     * `RESOURCEnnn` identifier.
      *
-     * Adding identical bytes again is idempotent: the existing resource is
-     * returned instead of a duplicate. A later {@see self::updateItem()} whose
-     * item XML references the returned href ({@see Resource::$href}) reuses this
-     * resource rather than re-adding it.
+     * A later {@see self::updateItem()} whose item XML references `$path` reuses
+     * this resource rather than re-adding it. Throws when `$path` is absolute or
+     * escapes the package (`..`), or when the package already holds a file at
+     * `$path`.
      */
-    public function addResource(QtiPackage $package, string $filename, string $content, bool $isBinary = true): EditResult
+    public function addResource(QtiPackage $package, string $path, string $content, bool $isBinary = true): EditResult
     {
-        $href = $this->contentAddressedHref($filename, $content);
-
-        $existing = $this->resourceByHref($package, $href);
-        if ($existing !== null) {
-            return new EditResult($existing, new StringCollection());
+        $this->assertValidResourcePath($path);
+        if ($this->resourceByHref($package, $path) !== null) {
+            throw new InvalidArgumentException(sprintf('Package already contains a resource at path "%s"', $path));
         }
 
         $resource = new Webcontent(
-            $href,
-            $this->webcontentProcessor->availableWebcontentIdentifier($package),
-            $href,
+            $path,
+            $this->webcontentIdentifierGenerator->nextIdentifier($this->resourceIdentifiers($package)),
+            $path,
             new MemoryFileContent($content),
             $isBinary,
         );
@@ -234,18 +234,28 @@ final readonly class PackageEditor
     }
 
     /**
-     * Package-relative, content-addressed path for an uploaded asset: the md5
-     * of its bytes under `resources/`, keeping the original extension so the
-     * file type is preserved. Only a plain alphanumeric extension is kept; any
-     * other value (empty, or crafted) is dropped so the path stays confined to
-     * `resources/`.
+     * A resource path must stay inside the package: no absolute path and no
+     * `..` segment that would let a write escape the package directory.
      */
-    private function contentAddressedHref(string $filename, string $content): string
+    private function assertValidResourcePath(string $path): void
     {
-        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
-        $suffix = preg_match('/^[a-z0-9]+$/', $extension) === 1 ? '.' . $extension : '';
+        if ($path === ''
+            || str_starts_with($path, '/')
+            || preg_match('~(^|/)\.\.(/|$)~', $path) === 1
+        ) {
+            throw new InvalidArgumentException(sprintf('Invalid resource path "%s": must be a relative path inside the package', $path));
+        }
+    }
 
-        return 'resources/' . md5($content) . $suffix;
+    /**
+     * @return list<string>
+     */
+    private function resourceIdentifiers(QtiPackage $package): array
+    {
+        return array_map(
+            static fn(Resource $resource): string => $resource->identifier,
+            $package->resources->all(),
+        );
     }
 
     private function resourceByHref(QtiPackage $package, string $href): ?Resource

--- a/src/Package/Service/PackageEditor.php
+++ b/src/Package/Service/PackageEditor.php
@@ -17,6 +17,7 @@ use Qti3\AssessmentTest\Model\ItemRef\AssessmentItemRef;
 use Qti3\AssessmentTest\Service\TestBuilder;
 use Qti3\AssessmentTest\Service\TestParseResult;
 use Qti3\Package\Exception\InvalidQtiPackageException;
+use Qti3\Package\Model\FileContent\MemoryFileContent;
 use Qti3\Package\Model\Manifest\ManifestResourceDependency;
 use Qti3\Package\Model\Manifest\ManifestResourceDependencyCollection;
 use Qti3\Package\Model\PackageFile\XmlFile;
@@ -55,6 +56,39 @@ final readonly class PackageEditor
     public function getAvailableItemIdentifier(QtiPackage $package): string
     {
         return $this->identifierGenerator->nextIdentifier($this->itemIdentifiers($package));
+    }
+
+    /**
+     * Add a standalone webcontent asset (e.g. an uploaded image) to the package,
+     * independent of any item. The bytes are stored under `resources/` with a
+     * content-addressed name (md5 of the content plus the original extension)
+     * and registered as a `webcontent` resource with a fresh `RESOURCEnnn`
+     * identifier.
+     *
+     * Adding identical bytes again is idempotent: the existing resource is
+     * returned instead of a duplicate. A later {@see self::updateItem()} whose
+     * item XML references the returned href ({@see Resource::$href}) reuses this
+     * resource rather than re-adding it.
+     */
+    public function addResource(QtiPackage $package, string $filename, string $content, bool $isBinary = true): EditResult
+    {
+        $href = $this->contentAddressedHref($filename, $content);
+
+        $existing = $this->resourceByHref($package, $href);
+        if ($existing !== null) {
+            return new EditResult($existing, new StringCollection());
+        }
+
+        $resource = new Webcontent(
+            $href,
+            $this->webcontentProcessor->availableWebcontentIdentifier($package),
+            $href,
+            new MemoryFileContent($content),
+            $isBinary,
+        );
+        $package->addResource($resource);
+
+        return new EditResult($resource, new StringCollection());
     }
 
     /**
@@ -197,6 +231,32 @@ final readonly class PackageEditor
         foreach ($webcontent as $webcontentFile) {
             $package->addResource($webcontentFile);
         }
+    }
+
+    /**
+     * Package-relative, content-addressed path for an uploaded asset: the md5
+     * of its bytes under `resources/`, keeping the original extension so the
+     * file type is preserved. Only a plain alphanumeric extension is kept; any
+     * other value (empty, or crafted) is dropped so the path stays confined to
+     * `resources/`.
+     */
+    private function contentAddressedHref(string $filename, string $content): string
+    {
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        $suffix = preg_match('/^[a-z0-9]+$/', $extension) === 1 ? '.' . $extension : '';
+
+        return 'resources/' . md5($content) . $suffix;
+    }
+
+    private function resourceByHref(QtiPackage $package, string $href): ?Resource
+    {
+        foreach ($package->resources as $resource) {
+            if ($resource->href === $href) {
+                return $resource;
+            }
+        }
+
+        return null;
     }
 
     private function linkNewDependencies(QtiPackage $package, Resource $itemResource, ManifestResourceDependencyCollection $dependencies): void

--- a/src/Package/Service/WebcontentIdentifierGenerator.php
+++ b/src/Package/Service/WebcontentIdentifierGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Package\Service;
+
+/**
+ * Generates the next sequential webcontent resource identifier (`RESOURCE001`,
+ * `RESOURCE002`, ...).
+ *
+ * Gap-safe: the next number is derived from the highest existing `RESOURCEnnn`
+ * number plus one, never from the count, so gaps in the numbering never produce
+ * a colliding identifier. Mirrors {@see \Qti3\AssessmentItem\Service\ItemIdentifierGenerator}.
+ */
+final class WebcontentIdentifierGenerator
+{
+    private const string FORMAT = 'RESOURCE%03d';
+    private const string PATTERN = '/^RESOURCE(\d+)$/';
+
+    /**
+     * @param list<string> $existingIdentifiers
+     */
+    public function nextIdentifier(array $existingIdentifiers): string
+    {
+        $highest = 0;
+
+        foreach ($existingIdentifiers as $identifier) {
+            if (preg_match(self::PATTERN, $identifier, $matches) === 1) {
+                $highest = max($highest, (int) $matches[1]);
+            }
+        }
+
+        return sprintf(self::FORMAT, $highest + 1);
+    }
+}

--- a/src/Package/Service/WebcontentProcessor.php
+++ b/src/Package/Service/WebcontentProcessor.php
@@ -102,6 +102,12 @@ final readonly class WebcontentProcessor
         return [$dependencies, $newWebcontent];
     }
 
+    /** The next free `RESOURCEnnn` identifier for the package. */
+    public function availableWebcontentIdentifier(QtiPackage $package): string
+    {
+        return $this->nextWebcontentIdentifier(new WebcontentCollection(), $package);
+    }
+
     /**
      * The next free `RESOURCEnnn` identifier. When editing an existing package
      * the source may already contain webcontent resources, so an identifier is

--- a/src/Package/Service/WebcontentProcessor.php
+++ b/src/Package/Service/WebcontentProcessor.php
@@ -32,6 +32,7 @@ final readonly class WebcontentProcessor
     public function __construct(
         private IResourceValidator $resourceValidator,
         private IResourceDownloader $resourceDownloader,
+        private WebcontentIdentifierGenerator $identifierGenerator,
     ) {}
 
     /**
@@ -53,7 +54,7 @@ final readonly class WebcontentProcessor
             if (!$webcontentFile) {
                 $webcontentFile = new Webcontent(
                     $qtiResource->originalPath,
-                    $this->nextWebcontentIdentifier($webcontent, $sourcePackage),
+                    $this->identifierGenerator->nextIdentifier($this->usedIdentifiers($webcontent, $sourcePackage)),
                     $qtiResource->relativePath . $qtiResource->filename,
                     $this->contentFor($qtiResource->originalPath, $sourcePackage),
                     $qtiResource->isBinary,
@@ -102,36 +103,25 @@ final readonly class WebcontentProcessor
         return [$dependencies, $newWebcontent];
     }
 
-    /** The next free `RESOURCEnnn` identifier for the package. */
-    public function availableWebcontentIdentifier(QtiPackage $package): string
-    {
-        return $this->nextWebcontentIdentifier(new WebcontentCollection(), $package);
-    }
-
     /**
-     * The next free `RESOURCEnnn` identifier. When editing an existing package
-     * the source may already contain webcontent resources, so an identifier is
-     * only accepted once it collides with neither the current collection nor a
-     * resource already in the source package — otherwise a new media file could
-     * be handed an identifier that is already taken (e.g. RESOURCE001), yielding
-     * a duplicate resource and an invalid manifest.
+     * The identifiers already taken for the run: those of the webcontent
+     * gathered so far this pass plus every resource already in the source
+     * package. Feeding these to the generator keeps a new media file from being
+     * handed an identifier that is already in use.
+     *
+     * @return list<string>
      */
-    private function nextWebcontentIdentifier(WebcontentCollection $webcontent, ?QtiPackage $sourcePackage): string
+    private function usedIdentifiers(WebcontentCollection $webcontent, ?QtiPackage $sourcePackage): array
     {
-        $used = [];
+        $identifiers = [];
         foreach ($webcontent as $existing) {
-            $used[$existing->identifier] = true;
+            $identifiers[] = $existing->identifier;
         }
         foreach ($sourcePackage?->resources ?? [] as $resource) {
-            $used[$resource->identifier] = true;
+            $identifiers[] = $resource->identifier;
         }
 
-        $index = 1;
-        while (isset($used[$identifier = sprintf('RESOURCE%03d', $index)])) {
-            $index++;
-        }
-
-        return $identifier;
+        return $identifiers;
     }
 
     private function resourceByHref(QtiPackage $package, ?string $href): ?Resource

--- a/src/QtiClient.php
+++ b/src/QtiClient.php
@@ -33,6 +33,7 @@ use Qti3\Package\Downloader\Resource\IResourceDownloader;
 use Qti3\Package\Service\IZipPackageFactory;
 use Qti3\AssessmentItem\Service\ItemIdentifierGenerator;
 use Qti3\Package\Service\QtiPackageBuilder;
+use Qti3\Package\Service\WebcontentIdentifierGenerator;
 use Qti3\Package\Service\WebcontentProcessor;
 use Qti3\Package\Service\PackageEditor;
 use Qti3\Package\Validator\Resource\IResourceValidator;
@@ -189,6 +190,7 @@ final class QtiClient
             $this->getItemResourceBuilder(),
             $this->getWebcontentProcessor(),
             $this->getAssessmentItemParser(),
+            new WebcontentIdentifierGenerator(),
         );
     }
 
@@ -212,6 +214,7 @@ final class QtiClient
         return $this->webcontentProcessor ??= new WebcontentProcessor(
             $this->resourceValidator,
             $this->resourceDownloader,
+            new WebcontentIdentifierGenerator(),
         );
     }
 

--- a/tests/Integration/PackageEditorIntegrationTest.php
+++ b/tests/Integration/PackageEditorIntegrationTest.php
@@ -91,6 +91,50 @@ class PackageEditorIntegrationTest extends TestCase
         $this->assertSame(['ITEM001', 'ITEM002'], $test->getItemIdentifiers());
     }
 
+    #[Test]
+    public function anUploadedResourceIsReusedByALaterItemUpdateThatReferencesIt(): void
+    {
+        $this->seedPackageOnDisk();
+        $client = $this->createClient();
+        $editor = $client->getPackageEditor();
+
+        // Request 1: an uploaded file is added to the package and saved. The
+        // item XML does not reference it yet.
+        $package = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
+        $upload = $editor->addResource($package, 'photo.png', 'PNGBYTES');
+        $href = $upload->resource->href;
+        $resourceId = $upload->resource->identifier;
+        $client->getFilesystemPackageFactory()->getWriter(self::PACKAGE_DIR)->write($package);
+
+        // Request 2: reload and update an item whose new XML references the
+        // upload by its href.
+        $package = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
+        $itemXml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<qti-assessment-item xmlns="%s" identifier="ITEM001" title="Vraag" time-dependent="false">'
+            . '<qti-item-body><p><img src="%s" alt="Foto"/></p></qti-item-body></qti-assessment-item>',
+            self::ASI_NAMESPACE,
+            $href,
+        );
+        $item = $client->getAssessmentItemParser()->parseFromString($itemXml)->item;
+        $editor->updateItem($package, $item);
+        $client->getFilesystemPackageFactory()->getWriter(self::PACKAGE_DIR)->write($package);
+
+        // The item now depends on the uploaded resource, which was reused (not
+        // duplicated) and whose bytes persisted across both writes.
+        $reloaded = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
+        $this->assertSame('PNGBYTES', $reloaded->getFile($href)->getContent()->getContent());
+        $this->assertSame(1, count(array_filter(
+            $reloaded->resources->all(),
+            static fn($resource): bool => $resource->href === $href,
+        )));
+        $dependencyRefs = array_map(
+            static fn($dependency): string => $dependency->identifierref,
+            $reloaded->getResource('ITEM001')->resourceDependencies->all(),
+        );
+        $this->assertContains($resourceId, $dependencyRefs);
+    }
+
     private function seedPackageOnDisk(): void
     {
         $dir = $this->tempDataDir . '/' . self::PACKAGE_DIR;

--- a/tests/Integration/PackageEditorIntegrationTest.php
+++ b/tests/Integration/PackageEditorIntegrationTest.php
@@ -101,7 +101,7 @@ class PackageEditorIntegrationTest extends TestCase
         // Request 1: an uploaded file is added to the package and saved. The
         // item XML does not reference it yet.
         $package = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
-        $upload = $editor->addResource($package, 'photo.png', 'PNGBYTES');
+        $upload = $editor->addResource($package, 'resources/photo.png', 'PNGBYTES');
         $href = $upload->resource->href;
         $resourceId = $upload->resource->identifier;
         $client->getFilesystemPackageFactory()->getWriter(self::PACKAGE_DIR)->write($package);

--- a/tests/Integration/PackageEditorIntegrationTest.php
+++ b/tests/Integration/PackageEditorIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Qti3\Tests\Integration;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Qti3\Package\Model\FileContent\MemoryFileContent;
 
 #[Group('integration')]
 class PackageEditorIntegrationTest extends TestCase
@@ -101,7 +102,7 @@ class PackageEditorIntegrationTest extends TestCase
         // Request 1: an uploaded file is added to the package and saved. The
         // item XML does not reference it yet.
         $package = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
-        $upload = $editor->addResource($package, 'resources/photo.png', 'PNGBYTES');
+        $upload = $editor->addResource($package, 'resources/photo.png', new MemoryFileContent('PNGBYTES'));
         $href = $upload->resource->href;
         $resourceId = $upload->resource->identifier;
         $client->getFilesystemPackageFactory()->getWriter(self::PACKAGE_DIR)->write($package);

--- a/tests/Unit/Package/Service/PackageEditorTest.php
+++ b/tests/Unit/Package/Service/PackageEditorTest.php
@@ -9,6 +9,8 @@ use DOMElement;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Qti3\AssessmentItem\Model\AssessmentItem;
@@ -531,49 +533,32 @@ final class PackageEditorTest extends TestCase
     }
 
     #[Test]
-    public function addResourceRegistersAContentAddressedWebcontentResource(): void
+    public function addResourceRegistersAWebcontentResourceAtTheGivenPath(): void
     {
         $package = $this->emptyDraft();
 
-        $result = $this->editor->addResource($package, 'photo.png', 'PNGBYTES');
+        $result = $this->editor->addResource($package, 'resources/photo.png', 'PNGBYTES');
 
-        $expectedHref = 'resources/' . md5('PNGBYTES') . '.png';
         $this->assertSame('RESOURCE001', $result->resource->identifier);
-        $this->assertSame($expectedHref, $result->resource->href);
-        $this->assertSame('PNGBYTES', $package->getFile($expectedHref)->getContent()->getContent());
+        $this->assertSame('resources/photo.png', $result->resource->href);
+        $this->assertSame('PNGBYTES', $package->getFile('resources/photo.png')->getContent()->getContent());
 
         $manifestResource = $this->findElement((string) $package->manifest, self::MANIFEST_NAMESPACE, 'resource', 'RESOURCE001');
         $this->assertInstanceOf(DOMElement::class, $manifestResource);
         $this->assertSame('webcontent', $manifestResource->getAttribute('type'));
-        $this->assertSame($expectedHref, $manifestResource->getAttribute('href'));
+        $this->assertSame('resources/photo.png', $manifestResource->getAttribute('href'));
     }
 
     #[Test]
-    public function addResourceIsIdempotentForIdenticalContent(): void
+    public function addResourceAssignsSequentialIdentifiers(): void
     {
         $package = $this->emptyDraft();
 
-        $first = $this->editor->addResource($package, 'a.png', 'SAME');
-        $second = $this->editor->addResource($package, 'b.png', 'SAME');
-
-        // Identical bytes resolve to the same content-addressed resource, so no
-        // duplicate is created and the original identifier is returned.
-        $this->assertSame($first->resource->identifier, $second->resource->identifier);
-        $this->assertSame($first->resource->href, $second->resource->href);
-        $this->assertSame(1, $this->countResourcesWithHref($package, $first->resource->href));
-    }
-
-    #[Test]
-    public function addResourceCreatesDistinctResourcesForDifferentContent(): void
-    {
-        $package = $this->emptyDraft();
-
-        $first = $this->editor->addResource($package, 'a.png', 'ONE');
-        $second = $this->editor->addResource($package, 'b.png', 'TWO');
+        $first = $this->editor->addResource($package, 'resources/one.png', 'ONE');
+        $second = $this->editor->addResource($package, 'resources/two.png', 'TWO');
 
         $this->assertSame('RESOURCE001', $first->resource->identifier);
         $this->assertSame('RESOURCE002', $second->resource->identifier);
-        $this->assertNotSame($first->resource->href, $second->resource->href);
     }
 
     #[Test]
@@ -582,19 +567,42 @@ final class PackageEditorTest extends TestCase
         // The package already owns RESOURCE001.
         $package = $this->draftWithExistingWebcontent();
 
-        $result = $this->editor->addResource($package, 'photo.png', 'PNGBYTES');
+        $result = $this->editor->addResource($package, 'resources/photo.png', 'PNGBYTES');
 
         $this->assertSame('RESOURCE002', $result->resource->identifier);
     }
 
     #[Test]
-    public function addResourceDropsAnUnusableExtension(): void
+    public function addResourceThrowsWhenAResourceAlreadyExistsAtThePath(): void
+    {
+        $package = $this->emptyDraft();
+        $this->editor->addResource($package, 'resources/photo.png', 'FIRST');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->editor->addResource($package, 'resources/photo.png', 'SECOND');
+    }
+
+    #[Test]
+    #[DataProvider('invalidResourcePathProvider')]
+    public function addResourceRejectsPathsThatEscapeThePackage(string $path): void
     {
         $package = $this->emptyDraft();
 
-        $result = $this->editor->addResource($package, 'noextension', 'BYTES');
+        $this->expectException(InvalidArgumentException::class);
 
-        $this->assertSame('resources/' . md5('BYTES'), $result->resource->href);
+        $this->editor->addResource($package, $path, 'BYTES');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidResourcePathProvider(): iterable
+    {
+        yield 'absolute path' => ['/etc/passwd'];
+        yield 'parent traversal' => ['../secret.png'];
+        yield 'nested traversal' => ['resources/../../secret.png'];
+        yield 'empty path' => [''];
     }
 
     // --- editor convenience --------------------------------------------------

--- a/tests/Unit/Package/Service/PackageEditorTest.php
+++ b/tests/Unit/Package/Service/PackageEditorTest.php
@@ -530,6 +530,73 @@ final class PackageEditorTest extends TestCase
         $this->assertContains('META1', $dependencies);
     }
 
+    #[Test]
+    public function addResourceRegistersAContentAddressedWebcontentResource(): void
+    {
+        $package = $this->emptyDraft();
+
+        $result = $this->editor->addResource($package, 'photo.png', 'PNGBYTES');
+
+        $expectedHref = 'resources/' . md5('PNGBYTES') . '.png';
+        $this->assertSame('RESOURCE001', $result->resource->identifier);
+        $this->assertSame($expectedHref, $result->resource->href);
+        $this->assertSame('PNGBYTES', $package->getFile($expectedHref)->getContent()->getContent());
+
+        $manifestResource = $this->findElement((string) $package->manifest, self::MANIFEST_NAMESPACE, 'resource', 'RESOURCE001');
+        $this->assertInstanceOf(DOMElement::class, $manifestResource);
+        $this->assertSame('webcontent', $manifestResource->getAttribute('type'));
+        $this->assertSame($expectedHref, $manifestResource->getAttribute('href'));
+    }
+
+    #[Test]
+    public function addResourceIsIdempotentForIdenticalContent(): void
+    {
+        $package = $this->emptyDraft();
+
+        $first = $this->editor->addResource($package, 'a.png', 'SAME');
+        $second = $this->editor->addResource($package, 'b.png', 'SAME');
+
+        // Identical bytes resolve to the same content-addressed resource, so no
+        // duplicate is created and the original identifier is returned.
+        $this->assertSame($first->resource->identifier, $second->resource->identifier);
+        $this->assertSame($first->resource->href, $second->resource->href);
+        $this->assertSame(1, $this->countResourcesWithHref($package, $first->resource->href));
+    }
+
+    #[Test]
+    public function addResourceCreatesDistinctResourcesForDifferentContent(): void
+    {
+        $package = $this->emptyDraft();
+
+        $first = $this->editor->addResource($package, 'a.png', 'ONE');
+        $second = $this->editor->addResource($package, 'b.png', 'TWO');
+
+        $this->assertSame('RESOURCE001', $first->resource->identifier);
+        $this->assertSame('RESOURCE002', $second->resource->identifier);
+        $this->assertNotSame($first->resource->href, $second->resource->href);
+    }
+
+    #[Test]
+    public function addResourceSkipsIdentifiersAlreadyUsedInThePackage(): void
+    {
+        // The package already owns RESOURCE001.
+        $package = $this->draftWithExistingWebcontent();
+
+        $result = $this->editor->addResource($package, 'photo.png', 'PNGBYTES');
+
+        $this->assertSame('RESOURCE002', $result->resource->identifier);
+    }
+
+    #[Test]
+    public function addResourceDropsAnUnusableExtension(): void
+    {
+        $package = $this->emptyDraft();
+
+        $result = $this->editor->addResource($package, 'noextension', 'BYTES');
+
+        $this->assertSame('resources/' . md5('BYTES'), $result->resource->href);
+    }
+
     // --- editor convenience --------------------------------------------------
 
     private function addItem(QtiPackage $package, string $testId = self::TEST_ID): Resource

--- a/tests/Unit/Package/Service/PackageEditorTest.php
+++ b/tests/Unit/Package/Service/PackageEditorTest.php
@@ -17,6 +17,7 @@ use Qti3\AssessmentItem\Model\AssessmentItem;
 use Qti3\AssessmentTest\Exception\InvalidAssessmentTestException;
 use Qti3\AssessmentTest\Exception\InvalidItemOrderException;
 use Qti3\Package\Filesystem\FlysystemPackageFactory;
+use Qti3\Package\Model\FileContent\MemoryFileContent;
 use Qti3\Package\Model\PackageFile\XmlFile;
 use Qti3\Package\Model\QtiPackage;
 use Qti3\Package\Model\Resource\Resource;
@@ -537,7 +538,7 @@ final class PackageEditorTest extends TestCase
     {
         $package = $this->emptyDraft();
 
-        $result = $this->editor->addResource($package, 'resources/photo.png', 'PNGBYTES');
+        $result = $this->editor->addResource($package, 'resources/photo.png', new MemoryFileContent('PNGBYTES'));
 
         $this->assertSame('RESOURCE001', $result->resource->identifier);
         $this->assertSame('resources/photo.png', $result->resource->href);
@@ -554,8 +555,8 @@ final class PackageEditorTest extends TestCase
     {
         $package = $this->emptyDraft();
 
-        $first = $this->editor->addResource($package, 'resources/one.png', 'ONE');
-        $second = $this->editor->addResource($package, 'resources/two.png', 'TWO');
+        $first = $this->editor->addResource($package, 'resources/one.png', new MemoryFileContent('ONE'));
+        $second = $this->editor->addResource($package, 'resources/two.png', new MemoryFileContent('TWO'));
 
         $this->assertSame('RESOURCE001', $first->resource->identifier);
         $this->assertSame('RESOURCE002', $second->resource->identifier);
@@ -567,7 +568,7 @@ final class PackageEditorTest extends TestCase
         // The package already owns RESOURCE001.
         $package = $this->draftWithExistingWebcontent();
 
-        $result = $this->editor->addResource($package, 'resources/photo.png', 'PNGBYTES');
+        $result = $this->editor->addResource($package, 'resources/photo.png', new MemoryFileContent('PNGBYTES'));
 
         $this->assertSame('RESOURCE002', $result->resource->identifier);
     }
@@ -576,11 +577,11 @@ final class PackageEditorTest extends TestCase
     public function addResourceThrowsWhenAResourceAlreadyExistsAtThePath(): void
     {
         $package = $this->emptyDraft();
-        $this->editor->addResource($package, 'resources/photo.png', 'FIRST');
+        $this->editor->addResource($package, 'resources/photo.png', new MemoryFileContent('FIRST'));
 
         $this->expectException(InvalidArgumentException::class);
 
-        $this->editor->addResource($package, 'resources/photo.png', 'SECOND');
+        $this->editor->addResource($package, 'resources/photo.png', new MemoryFileContent('SECOND'));
     }
 
     #[Test]
@@ -591,7 +592,7 @@ final class PackageEditorTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $this->editor->addResource($package, $path, 'BYTES');
+        $this->editor->addResource($package, $path, new MemoryFileContent('BYTES'));
     }
 
     /**

--- a/tests/Unit/Package/Service/QtiPackageBuilderTest.php
+++ b/tests/Unit/Package/Service/QtiPackageBuilderTest.php
@@ -13,6 +13,7 @@ use Qti3\Package\Model\Resource\Resource;
 use Qti3\Package\Model\Resource\ResourceType;
 use Qti3\Package\Downloader\Resource\IResourceDownloader;
 use Qti3\Package\Service\QtiPackageBuilder;
+use Qti3\Package\Service\WebcontentIdentifierGenerator;
 use Qti3\Package\Service\WebcontentProcessor;
 use Qti3\Package\Validator\Resource\IResourceValidator;
 use Qti3\Package\Service\QtiPackageBuilder\ItemResourceBuilder;
@@ -48,6 +49,7 @@ class QtiPackageBuilderTest extends TestCase
             new WebcontentProcessor(
                 $this->resourceValidator,
                 $this->createMock(IResourceDownloader::class),
+                new WebcontentIdentifierGenerator(),
             ),
         );
     }

--- a/tests/Unit/Package/Service/WebcontentIdentifierGeneratorTest.php
+++ b/tests/Unit/Package/Service/WebcontentIdentifierGeneratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Tests\Unit\Package\Service;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Qti3\Package\Service\WebcontentIdentifierGenerator;
+
+final class WebcontentIdentifierGeneratorTest extends TestCase
+{
+    /**
+     * @param list<string> $existingIdentifiers
+     */
+    #[Test]
+    #[DataProvider('identifierProvider')]
+    public function itGeneratesTheNextSequentialIdentifier(array $existingIdentifiers, string $expected): void
+    {
+        $next = (new WebcontentIdentifierGenerator())->nextIdentifier($existingIdentifiers);
+
+        $this->assertSame($expected, $next);
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, string}>
+     */
+    public static function identifierProvider(): iterable
+    {
+        yield 'empty package starts at RESOURCE001' => [[], 'RESOURCE001'];
+        yield 'sequential identifiers' => [['RESOURCE001', 'RESOURCE002'], 'RESOURCE003'];
+        yield 'gap-safe: uses highest + 1, not count' => [['RESOURCE001', 'RESOURCE017'], 'RESOURCE018'];
+        yield 'unordered identifiers' => [['RESOURCE005', 'RESOURCE002'], 'RESOURCE006'];
+        yield 'ignores non-webcontent identifiers' => [['ITEM001', 'RESOURCE001', 'test'], 'RESOURCE002'];
+        yield 'numbers beyond three digits are not truncated' => [['RESOURCE1000'], 'RESOURCE1001'];
+    }
+}


### PR DESCRIPTION
## Summary

Adds `PackageEditor::addResource()` to add a standalone `webcontent` asset (e.g. an uploaded image) to a package, independent of any item.

This supports a two-step editor flow: a file is uploaded and added to the package first, and the item XML that references it arrives in a later request.

## API

```php
public function addResource(QtiPackage $package, string $path, IFileContent $content, bool $isBinary = true): EditResult
```

- **The caller supplies the package-relative `$path`** (e.g. `resources/photo.png`); the file is registered as a `webcontent` resource with a fresh `RESOURCEnnn` identifier. `$result->resource->href` is the path to reference from the item XML.
- **Content is an `IFileContent`** — pass `MemoryFileContent` for raw bytes, or a lazy/streaming implementation. It is handed straight to the `Webcontent` resource.
- **Path validation:** an absolute path or a `..` traversal segment is rejected, so a write can never escape the package.
- **Duplicate path throws:** adding a second resource at an existing path is rejected — the caller is responsible for choosing a unique path.
- **Directories:** intermediate directories in the path are created by the writers (Flysystem / zip) at save time; no explicit handling needed.

## Reuse on a later item update

The existing in-package media path already flows through `WebcontentProcessor`: when a later `updateItem()` receives XML whose `<img src>` references the returned href, the resource is reused (matched by href) and its dependency linked automatically — no duplicate resource or dependency is created.

## Identifier allocation

Introduces `WebcontentIdentifierGenerator`, mirroring `ItemIdentifierGenerator` (`nextIdentifier(array $existing)`, gap-safe: highest + 1). Both `PackageEditor` and `WebcontentProcessor` use it, replacing the previous ad-hoc `RESOURCEnnn` allocation.

## Design notes / review history

The API evolved during review:
- Initially the editor generated a content-addressed href (`resources/<md5>.<ext>`); per maintainer feedback this moved to a **caller-provided path**. Dropping content-addressing also removed the md5 hashing (mooting a Copilot MD5-collision comment) and the extension handling.
- Content changed from a raw `string` to an **`IFileContent`** so callers aren't limited to in-memory bytes.
- The `RESOURCEnnn` allocation was extracted into a dedicated generator (replacing an awkward empty-collection wrapper).

Scoped to `webcontent` (the media/upload use case); arbitrary resource types are out of scope.

## Tests

- Unit: registration + manifest entry at the given path, sequential identifiers, identifier skipping when the package already owns `RESOURCEnnn`, duplicate-path rejection, and path-escape rejection (absolute / `..` / empty, via a data provider).
- `WebcontentIdentifierGeneratorTest` (mirrors the item generator test).
- Integration: the full `upload -> save -> reload -> item update referencing it` round trip, asserting the bytes persist, the resource is reused (not duplicated) and the item depends on it.
- Full suite green (660 tests); phpstan green (level 0, the CI invocation).

## Docs

`docs/package-editor.md` gains an "Adding a resource" section describing the two-step flow and the `IFileContent` / caller-provided-path API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)