### PR TITLE
Add inline choice support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ $outcomes = $itemState->outcomeSet->outcomes;
 
 ### Supported interactions
 
-The `AssessmentItem` parser supports exactly the interaction types listed below via the `InteractionParser` used by `ItemBodyParser`. Other QTI 3.0 interaction types (e.g. `qti-inline-choice-interaction`, `qti-associate-interaction`, `qti-slider-interaction`, `qti-media-interaction`, the graphic interactions) are **not** supported: parsing such an item throws a `ParseError`, and the item editor (UC-P6) refuses packages containing them.
+The `AssessmentItem` parser supports exactly the interaction types listed below via the `InteractionParser` used by `ItemBodyParser`. Other QTI 3.0 interaction types (e.g. `qti-associate-interaction`, `qti-slider-interaction`, `qti-media-interaction`, the graphic interactions) are **not** supported: parsing such an item throws a `ParseError`, and the item editor (UC-P6) refuses packages containing them.
 
 - `qti-choice-interaction`
 - `qti-text-entry-interaction`
@@ -231,6 +231,7 @@ The `AssessmentItem` parser supports exactly the interaction types listed below 
 - `qti-gap-match-interaction`
 - `qti-hotspot-interaction`
 - `qti-hottext-interaction`
+- `qti-inline-choice-interaction`
 - `qti-match-interaction`
 - `qti-order-interaction`
 - `qti-select-point-interaction`

--- a/src/AssessmentItem/Model/Interaction/AbstractInteractionElement.php
+++ b/src/AssessmentItem/Model/Interaction/AbstractInteractionElement.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\AssessmentItem\Model\Interaction;
+
+use Qti3\Shared\Model\QtiElement;
+use Qti3\Shared\Model\SharedAttributes;
+
+abstract class AbstractInteractionElement extends QtiElement
+{
+    public readonly ?string $id;
+    public readonly ?string $class;
+    public readonly ?string $xmlLang;
+    public readonly ?string $label;
+    public readonly ?string $dir;
+    public readonly ?string $role;
+
+    /** @var array<string,string> */
+    public readonly array $ariaAttributes;
+
+    /** @var array<string,string> */
+    public readonly array $dataAttributes;
+
+    public function __construct(SharedAttributes $attributes = new SharedAttributes())
+    {
+        $this->id = $attributes->id;
+        $this->class = $attributes->class;
+        $this->xmlLang = $attributes->xmlLang;
+        $this->label = $attributes->label;
+        $this->dir = $attributes->dir;
+        $this->role = $attributes->role;
+        $this->ariaAttributes = $attributes->ariaAttributes;
+        $this->dataAttributes = $attributes->dataAttributes;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    protected function sharedAttributes(): array
+    {
+        $named = array_filter([
+            'id' => $this->id,
+            'class' => $this->class,
+            'xml:lang' => $this->xmlLang,
+            'label' => $this->label,
+            'dir' => $this->dir,
+            'role' => $this->role,
+        ], static fn (?string $value): bool => $value !== null);
+
+        return [
+            ...$named,
+            ...$this->ariaAttributes,
+            ...$this->dataAttributes,
+        ];
+    }
+}

--- a/src/AssessmentItem/Model/Interaction/ChoiceInteraction/ChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/ChoiceInteraction/ChoiceInteraction.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
+use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\Orientation;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\QtiElement;
 
 /**
  * The choice interaction allows a candidate to supply a response by selecting one or more choices from a list.
  */
-class ChoiceInteraction extends QtiElement
+class ChoiceInteraction extends AbstractInteractionElement
 {
     /**
      * @param array<int,SimpleChoice> $choices
@@ -21,7 +24,12 @@ class ChoiceInteraction extends QtiElement
         public ?Prompt $prompt = null,
         public bool $shuffle = false,
         public int $maxChoices = 1,
-    ) {}
+        public ?int $minChoices = null,
+        public ?Orientation $orientation = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -29,6 +37,9 @@ class ChoiceInteraction extends QtiElement
             'response-identifier' => $this->responseIdentifier,
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'max-choices' => (string) $this->maxChoices,
+            'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
+            'orientation' => $this->orientation?->value,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/ChoiceInteraction/ChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/ChoiceInteraction/ChoiceInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\Orientation;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
@@ -13,7 +13,7 @@ use Qti3\Shared\Model\QtiElement;
 /**
  * The choice interaction allows a candidate to supply a response by selecting one or more choices from a list.
  */
-class ChoiceInteraction extends AbstractInteractionElement
+class ChoiceInteraction extends AbstractSharedAttributeElement
 {
     /**
      * @param array<int,SimpleChoice> $choices

--- a/src/AssessmentItem/Model/Interaction/ChoiceInteraction/ChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/ChoiceInteraction/ChoiceInteraction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\Orientation;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\QtiElement;
@@ -13,7 +13,7 @@ use Qti3\Shared\Model\QtiElement;
 /**
  * The choice interaction allows a candidate to supply a response by selecting one or more choices from a list.
  */
-class ChoiceInteraction extends AbstractSharedAttributeElement
+class ChoiceInteraction extends AbstractBaseSequenceElement
 {
     /**
      * @param array<int,SimpleChoice> $choices
@@ -26,7 +26,7 @@ class ChoiceInteraction extends AbstractSharedAttributeElement
         public int $maxChoices = 1,
         public ?int $minChoices = null,
         public ?Orientation $orientation = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -39,7 +39,7 @@ class ChoiceInteraction extends AbstractSharedAttributeElement
             'max-choices' => (string) $this->maxChoices,
             'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'orientation' => $this->orientation?->value,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/ChoiceInteraction/SimpleChoice.php
+++ b/src/AssessmentItem/Model/Interaction/ChoiceInteraction/SimpleChoice.php
@@ -5,21 +5,32 @@ declare(strict_types=1);
 namespace Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction;
 
 use Qti3\AssessmentItem\Model\Feedback\FeedbackInline;
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\QtiElement;
 
-class SimpleChoice extends QtiElement
+class SimpleChoice extends AbstractInteractionElement
 {
     public function __construct(
         public string $identifier,
         public ContentNodeCollection $content,
         public ?FeedbackInline $feedbackInline = null,
-    ) {}
+        public bool $fixed = false,
+        public ?string $templateIdentifier = null,
+        public string $showHide = 'show',
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'identifier' => $this->identifier,
+            'fixed' => $this->fixed ? 'true' : null,
+            'template-identifier' => $this->templateIdentifier,
+            'show-hide' => $this->showHide,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/ChoiceInteraction/SimpleChoice.php
+++ b/src/AssessmentItem/Model/Interaction/ChoiceInteraction/SimpleChoice.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction;
 
 use Qti3\AssessmentItem\Model\Feedback\FeedbackInline;
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-class SimpleChoice extends AbstractInteractionElement
+class SimpleChoice extends AbstractSharedAttributeElement
 {
     public function __construct(
         public string $identifier,

--- a/src/AssessmentItem/Model/Interaction/ChoiceInteraction/SimpleChoice.php
+++ b/src/AssessmentItem/Model/Interaction/ChoiceInteraction/SimpleChoice.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction;
 
 use Qti3\AssessmentItem\Model\Feedback\FeedbackInline;
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-class SimpleChoice extends AbstractSharedAttributeElement
+class SimpleChoice extends AbstractBaseSequenceElement
 {
     public function __construct(
         public string $identifier,
@@ -18,7 +18,7 @@ class SimpleChoice extends AbstractSharedAttributeElement
         public bool $fixed = false,
         public ?string $templateIdentifier = null,
         public string $showHide = 'show',
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -30,7 +30,7 @@ class SimpleChoice extends AbstractSharedAttributeElement
             'fixed' => $this->fixed ? 'true' : null,
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteraction.php
@@ -4,23 +4,47 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\ExtendedTextInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\QtiElement;
 
 /**
  * The extended text interaction allows a candidate to supply a text string for a response.
  */
-class ExtendedTextInteraction extends QtiElement
+class ExtendedTextInteraction extends AbstractInteractionElement
 {
     public function __construct(
         public string $responseIdentifier = 'RESPONSE',
         public ?Prompt $prompt = null,
-    ) {}
+        public ?int $base = null,
+        public ?string $stringIdentifier = null,
+        public ?int $expectedLength = null,
+        public ?string $patternMask = null,
+        public ?string $placeholderText = null,
+        public ?int $maxStrings = null,
+        public ?int $minStrings = null,
+        public ?int $expectedLines = null,
+        public ?string $format = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'response-identifier' => $this->responseIdentifier,
+            'base' => $this->base === null ? null : (string) $this->base,
+            'string-identifier' => $this->stringIdentifier,
+            'expected-length' => $this->expectedLength === null ? null : (string) $this->expectedLength,
+            'pattern-mask' => $this->patternMask,
+            'placeholder-text' => $this->placeholderText,
+            'max-strings' => $this->maxStrings === null ? null : (string) $this->maxStrings,
+            'min-strings' => $this->minStrings === null ? null : (string) $this->minStrings,
+            'expected-lines' => $this->expectedLines === null ? null : (string) $this->expectedLines,
+            'format' => $this->format,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteraction.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\ExtendedTextInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\QtiElement;
 
 /**
  * The extended text interaction allows a candidate to supply a text string for a response.
  */
-class ExtendedTextInteraction extends AbstractSharedAttributeElement
+class ExtendedTextInteraction extends AbstractBaseSequenceElement
 {
     public function __construct(
         public string $responseIdentifier = 'RESPONSE',
@@ -26,7 +26,7 @@ class ExtendedTextInteraction extends AbstractSharedAttributeElement
         public ?int $minStrings = null,
         public ?int $expectedLines = null,
         public ?string $format = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -44,7 +44,7 @@ class ExtendedTextInteraction extends AbstractSharedAttributeElement
             'min-strings' => $this->minStrings === null ? null : (string) $this->minStrings,
             'expected-lines' => $this->expectedLines === null ? null : (string) $this->expectedLines,
             'format' => $this->format,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\ExtendedTextInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\QtiElement;
@@ -12,7 +12,7 @@ use Qti3\Shared\Model\QtiElement;
 /**
  * The extended text interaction allows a candidate to supply a text string for a response.
  */
-class ExtendedTextInteraction extends AbstractInteractionElement
+class ExtendedTextInteraction extends AbstractSharedAttributeElement
 {
     public function __construct(
         public string $responseIdentifier = 'RESPONSE',

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/Gap.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/Gap.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 
-final class Gap extends AbstractSharedAttributeElement
+final class Gap extends AbstractBaseSequenceElement
 {
     public function __construct(
         public readonly string $identifier,
@@ -15,7 +15,7 @@ final class Gap extends AbstractSharedAttributeElement
         public readonly string $showHide = 'show',
         public readonly ?string $matchGroup = null,
         public readonly bool $required = false,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -28,7 +28,7 @@ final class Gap extends AbstractSharedAttributeElement
             'show-hide' => $this->showHide,
             'match-group' => $this->matchGroup,
             'required' => $this->required ? 'true' : null,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 }

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/Gap.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/Gap.php
@@ -4,18 +4,31 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\Shared\Model\QtiElement;
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 
-final class Gap extends QtiElement
+final class Gap extends AbstractInteractionElement
 {
     public function __construct(
         public readonly string $identifier,
-    ) {}
+        public readonly ?string $templateIdentifier = null,
+        public readonly string $showHide = 'show',
+        public readonly ?string $matchGroup = null,
+        public readonly bool $required = false,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'identifier' => $this->identifier,
+            'template-identifier' => $this->templateIdentifier,
+            'show-hide' => $this->showHide,
+            'match-group' => $this->matchGroup,
+            'required' => $this->required ? 'true' : null,
+            ...$this->sharedAttributes(),
         ];
     }
 }

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/Gap.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/Gap.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 
-final class Gap extends AbstractInteractionElement
+final class Gap extends AbstractSharedAttributeElement
 {
     public function __construct(
         public readonly string $identifier,

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\AssessmentItem\Model\ItemBody;
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 /**
  * The gap match interaction requires the candidate to match items in one list with items in another list.
  */
-final class GapMatchInteraction extends AbstractInteractionElement
+final class GapMatchInteraction extends AbstractSharedAttributeElement
 {
     /**
      * @var array<int,string>

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteraction.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\AssessmentItem\Model\ItemBody;
 use Qti3\Shared\Model\ContentNodeCollection;
 use Qti3\Shared\Model\HTMLTag;
 use Qti3\Shared\Model\IContentNode;
-use Qti3\Shared\Model\QtiElement;
 use InvalidArgumentException;
 
 /**
  * The gap match interaction requires the candidate to match items in one list with items in another list.
  */
-final class GapMatchInteraction extends QtiElement
+final class GapMatchInteraction extends AbstractInteractionElement
 {
     /**
      * @var array<int,string>
@@ -29,7 +30,10 @@ final class GapMatchInteraction extends QtiElement
         public readonly bool $shuffle = false,
         public readonly ?int $maxAssociations = 0,
         public readonly ?int $minAssociations = null,
+        SharedAttributes $attributes = new SharedAttributes(),
     ) {
+        parent::__construct($attributes);
+
         if (count($content) === 0) {
             throw new InvalidArgumentException('GapMatch must have some content');
         }
@@ -47,7 +51,7 @@ final class GapMatchInteraction extends QtiElement
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'max-associations' => $this->maxAssociations === null ? null : (string) $this->maxAssociations,
             'min-associations' => $this->minAssociations === null ? null : (string) $this->minAssociations,
-            'class' => null,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteraction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\AssessmentItem\Model\ItemBody;
 use Qti3\Shared\Model\ContentNodeCollection;
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 /**
  * The gap match interaction requires the candidate to match items in one list with items in another list.
  */
-final class GapMatchInteraction extends AbstractSharedAttributeElement
+final class GapMatchInteraction extends AbstractBaseSequenceElement
 {
     /**
      * @var array<int,string>
@@ -30,7 +30,7 @@ final class GapMatchInteraction extends AbstractSharedAttributeElement
         public readonly bool $shuffle = false,
         public readonly ?int $maxAssociations = 0,
         public readonly ?int $minAssociations = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
 
@@ -51,7 +51,7 @@ final class GapMatchInteraction extends AbstractSharedAttributeElement
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'max-associations' => $this->maxAssociations === null ? null : (string) $this->maxAssociations,
             'min-associations' => $this->minAssociations === null ? null : (string) $this->minAssociations,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapText.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapText.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\QtiElement;
 
-final class GapText extends QtiElement
+final class GapText extends AbstractInteractionElement
 {
     public function __construct(
         public readonly string $identifier,
@@ -18,7 +19,10 @@ final class GapText extends QtiElement
         //	Identifier of a template variable used to control the visibility of the qti-gap-text
         public readonly ?string $templateIdentifier = null,
         public readonly string $showHide = 'show',
-    ) {}
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -29,6 +33,7 @@ final class GapText extends QtiElement
             'match-group' => $this->matchGroup,
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapText.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapText.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-final class GapText extends AbstractSharedAttributeElement
+final class GapText extends AbstractBaseSequenceElement
 {
     public function __construct(
         public readonly string $identifier,
@@ -19,7 +19,7 @@ final class GapText extends AbstractSharedAttributeElement
         //	Identifier of a template variable used to control the visibility of the qti-gap-text
         public readonly ?string $templateIdentifier = null,
         public readonly string $showHide = 'show',
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -33,7 +33,7 @@ final class GapText extends AbstractSharedAttributeElement
             'match-group' => $this->matchGroup,
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapText.php
+++ b/src/AssessmentItem/Model/Interaction/GapMatchInteraction/GapText.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-final class GapText extends AbstractInteractionElement
+final class GapText extends AbstractSharedAttributeElement
 {
     public function __construct(
         public readonly string $identifier,

--- a/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoice.php
+++ b/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoice.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HotspotInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Shape\IShapeWithCoords;
-use Qti3\Shared\Model\QtiElement;
 
-class HotspotChoice extends QtiElement
+class HotspotChoice extends AbstractInteractionElement
 {
     public function __construct(
         public IShapeWithCoords $shape,
         public string $identifier,
-    ) {}
+        public ?string $templateIdentifier = null,
+        public string $showHide = 'show',
+        public ?string $hotspotLabel = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -20,6 +27,10 @@ class HotspotChoice extends QtiElement
             'shape' => $this->shape->name()->value,
             'coords' => (string) $this->shape->coords(),
             'identifier' => $this->identifier,
+            'template-identifier' => $this->templateIdentifier,
+            'show-hide' => $this->showHide,
+            'hotspot-label' => $this->hotspotLabel,
+            ...$this->sharedAttributes(),
         ];
     }
 }

--- a/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoice.php
+++ b/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoice.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HotspotInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Shape\IShapeWithCoords;
 
-class HotspotChoice extends AbstractSharedAttributeElement
+class HotspotChoice extends AbstractBaseSequenceElement
 {
     public function __construct(
         public IShapeWithCoords $shape,
@@ -16,7 +16,7 @@ class HotspotChoice extends AbstractSharedAttributeElement
         public ?string $templateIdentifier = null,
         public string $showHide = 'show',
         public ?string $hotspotLabel = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -30,7 +30,7 @@ class HotspotChoice extends AbstractSharedAttributeElement
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
             'hotspot-label' => $this->hotspotLabel,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 }

--- a/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoice.php
+++ b/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoice.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HotspotInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Shape\IShapeWithCoords;
 
-class HotspotChoice extends AbstractInteractionElement
+class HotspotChoice extends AbstractSharedAttributeElement
 {
     public function __construct(
         public IShapeWithCoords $shape,

--- a/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteraction.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HotspotInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\HTMLTag;
-use Qti3\Shared\Model\QtiElement;
 
 /**
  * The hotspot interaction allows a candidate to supply hotspots on an image for a response.
  */
-class HotspotInteraction extends QtiElement
+class HotspotInteraction extends AbstractInteractionElement
 {
     /**
      * @param array<int,HotspotChoice> $choices
@@ -20,13 +21,19 @@ class HotspotInteraction extends QtiElement
         public array $choices,
         public int $maxChoices,
         public string $responseIdentifier = 'RESPONSE',
-    ) {}
+        public ?int $minChoices = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'max-choices' => (string) $this->maxChoices,
+            'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'response-identifier' => $this->responseIdentifier,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteraction.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HotspotInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\HTMLTag;
 
 /**
  * The hotspot interaction allows a candidate to supply hotspots on an image for a response.
  */
-class HotspotInteraction extends AbstractSharedAttributeElement
+class HotspotInteraction extends AbstractBaseSequenceElement
 {
     /**
      * @param array<int,HotspotChoice> $choices
@@ -22,7 +22,7 @@ class HotspotInteraction extends AbstractSharedAttributeElement
         public int $maxChoices,
         public string $responseIdentifier = 'RESPONSE',
         public ?int $minChoices = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -33,7 +33,7 @@ class HotspotInteraction extends AbstractSharedAttributeElement
             'max-choices' => (string) $this->maxChoices,
             'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'response-identifier' => $this->responseIdentifier,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteraction.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HotspotInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\HTMLTag;
 
 /**
  * The hotspot interaction allows a candidate to supply hotspots on an image for a response.
  */
-class HotspotInteraction extends AbstractInteractionElement
+class HotspotInteraction extends AbstractSharedAttributeElement
 {
     /**
      * @param array<int,HotspotChoice> $choices

--- a/src/AssessmentItem/Model/Interaction/HottextInteraction/Hottext.php
+++ b/src/AssessmentItem/Model/Interaction/HottextInteraction/Hottext.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HottextInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-class Hottext extends AbstractSharedAttributeElement
+class Hottext extends AbstractBaseSequenceElement
 {
     public function __construct(
         public string $identifier,
         public ContentNodeCollection $content,
         public ?string $templateIdentifier = null,
         public string $showHide = 'show',
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -26,7 +26,7 @@ class Hottext extends AbstractSharedAttributeElement
             'identifier' => $this->identifier,
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/HottextInteraction/Hottext.php
+++ b/src/AssessmentItem/Model/Interaction/HottextInteraction/Hottext.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HottextInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-class Hottext extends AbstractInteractionElement
+class Hottext extends AbstractSharedAttributeElement
 {
     public function __construct(
         public string $identifier,

--- a/src/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HottextInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
@@ -14,7 +14,7 @@ use Qti3\Shared\Model\ContentNodeCollection;
  * as selectable runs of text embedded within a surrounding
  * context, such as a simple passage of text.
  */
-class HottextInteraction extends AbstractInteractionElement
+class HottextInteraction extends AbstractSharedAttributeElement
 {
     public function __construct(
         public int $maxChoices,

--- a/src/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteraction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HottextInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
 /**
@@ -14,14 +14,14 @@ use Qti3\Shared\Model\ContentNodeCollection;
  * as selectable runs of text embedded within a surrounding
  * context, such as a simple passage of text.
  */
-class HottextInteraction extends AbstractSharedAttributeElement
+class HottextInteraction extends AbstractBaseSequenceElement
 {
     public function __construct(
         public int $maxChoices,
         public ContentNodeCollection $content,
         public string $responseIdentifier = 'RESPONSE',
         public ?int $minChoices = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -32,7 +32,7 @@ class HottextInteraction extends AbstractSharedAttributeElement
             'max-choices' => (string) $this->maxChoices,
             'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'response-identifier' => $this->responseIdentifier,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteraction.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\HottextInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\QtiElement;
 
 /**
  * The HotTextInteraction.Type (qti-hottext-interaction)
@@ -13,19 +14,25 @@ use Qti3\Shared\Model\QtiElement;
  * as selectable runs of text embedded within a surrounding
  * context, such as a simple passage of text.
  */
-class HottextInteraction extends QtiElement
+class HottextInteraction extends AbstractInteractionElement
 {
     public function __construct(
         public int $maxChoices,
         public ContentNodeCollection $content,
         public string $responseIdentifier = 'RESPONSE',
-    ) {}
+        public ?int $minChoices = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'max-choices' => (string) $this->maxChoices,
+            'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'response-identifier' => $this->responseIdentifier,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
+
+use Qti3\Shared\Model\ContentNodeCollection;
+use Qti3\Shared\Model\QtiElement;
+
+/**
+ * A single selectable option (qti-inline-choice) within an
+ * {@see InlineChoiceInteraction}.
+ */
+class InlineChoice extends QtiElement
+{
+    public function __construct(
+        public string $identifier,
+        public ContentNodeCollection $content,
+        public bool $fixed = false,
+        // Identifier of a template variable used to control the visibility of the choice.
+        public ?string $templateIdentifier = null,
+        public string $showHide = 'show',
+    ) {}
+
+    public function attributes(): array
+    {
+        return [
+            'identifier' => $this->identifier,
+            'fixed' => $this->fixed ? 'true' : null,
+            'template-identifier' => $this->templateIdentifier,
+            'show-hide' => $this->showHide,
+        ];
+    }
+
+    public function children(): array
+    {
+        return $this->content->all();
+    }
+}

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
 /**
  * A single selectable option (qti-inline-choice) within an
  * {@see InlineChoiceInteraction}.
  */
-class InlineChoice extends AbstractSharedAttributeElement
+class InlineChoice extends AbstractBaseSequenceElement
 {
     public function __construct(
         public string $identifier,
@@ -21,7 +21,7 @@ class InlineChoice extends AbstractSharedAttributeElement
         // Identifier of a template variable used to control the visibility of the choice.
         public ?string $templateIdentifier = null,
         public string $showHide = 'show',
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -33,7 +33,7 @@ class InlineChoice extends AbstractSharedAttributeElement
             'fixed' => $this->fixed ? 'true' : null,
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
@@ -12,7 +12,7 @@ use Qti3\Shared\Model\ContentNodeCollection;
  * A single selectable option (qti-inline-choice) within an
  * {@see InlineChoiceInteraction}.
  */
-class InlineChoice extends AbstractInteractionElement
+class InlineChoice extends AbstractSharedAttributeElement
 {
     public function __construct(
         public string $identifier,

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoice.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\QtiElement;
 
 /**
  * A single selectable option (qti-inline-choice) within an
  * {@see InlineChoiceInteraction}.
  */
-class InlineChoice extends QtiElement
+class InlineChoice extends AbstractInteractionElement
 {
     public function __construct(
         public string $identifier,
@@ -20,7 +21,10 @@ class InlineChoice extends QtiElement
         // Identifier of a template variable used to control the visibility of the choice.
         public ?string $templateIdentifier = null,
         public string $showHide = 'show',
-    ) {}
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -29,6 +33,7 @@ class InlineChoice extends QtiElement
             'fixed' => $this->fixed ? 'true' : null,
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
@@ -4,9 +4,16 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\QtiElement;
 
-class InlineChoiceInteraction extends QtiElement
+/**
+ * The inline choice interaction (qti-inline-choice-interaction) presents a set
+ * of choices to the candidate inline, embedded in a surrounding run of content,
+ * from which a single choice must be selected (typically rendered as a drop-down).
+ */
+class InlineChoiceInteraction extends AbstractInteractionElement
 {
     /**
      * @param array<int,InlineChoice> $choices
@@ -16,7 +23,13 @@ class InlineChoiceInteraction extends QtiElement
         public string $responseIdentifier = 'RESPONSE',
         public bool $shuffle = false,
         public bool $required = false,
-    ) {}
+        public ?int $minChoices = null,
+        // The qti-label child element, distinct from the shared `label` attribute.
+        public ?Label $labelElement = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -24,15 +37,18 @@ class InlineChoiceInteraction extends QtiElement
             'response-identifier' => $this->responseIdentifier,
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'required' => $this->required ? 'true' : null,
+            'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
+            ...$this->sharedAttributes(),
         ];
     }
 
     /**
-     * @return array<int,QtiElement>
+     * @return array<int,QtiElement|null>
      */
     public function children(): array
     {
         return [
+            $this->labelElement,
             ...$this->choices,
         ];
     }

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\QtiElement;
 
 /**
@@ -13,7 +13,7 @@ use Qti3\Shared\Model\QtiElement;
  * of choices to the candidate inline, embedded in a surrounding run of content,
  * from which a single choice must be selected (typically rendered as a drop-down).
  */
-class InlineChoiceInteraction extends AbstractSharedAttributeElement
+class InlineChoiceInteraction extends AbstractBaseSequenceElement
 {
     /**
      * @param array<int,InlineChoice> $choices
@@ -26,7 +26,7 @@ class InlineChoiceInteraction extends AbstractSharedAttributeElement
         public ?int $minChoices = null,
         // The qti-label child element, distinct from the shared `label` attribute.
         public ?Label $labelElement = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -38,7 +38,7 @@ class InlineChoiceInteraction extends AbstractSharedAttributeElement
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'required' => $this->required ? 'true' : null,
             'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
+
+use Qti3\Shared\Model\QtiElement;
+
+class InlineChoiceInteraction extends QtiElement
+{
+    /**
+     * @param array<int,InlineChoice> $choices
+     */
+    public function __construct(
+        public array $choices,
+        public string $responseIdentifier = 'RESPONSE',
+        public bool $shuffle = false,
+        public bool $required = false,
+    ) {}
+
+    public function attributes(): array
+    {
+        return [
+            'response-identifier' => $this->responseIdentifier,
+            'shuffle' => $this->shuffle ? 'true' : 'false',
+            'required' => $this->required ? 'true' : null,
+        ];
+    }
+
+    /**
+     * @return array<int,QtiElement>
+     */
+    public function children(): array
+    {
+        return [
+            ...$this->choices,
+        ];
+    }
+}

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/InlineChoiceInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\QtiElement;
 
@@ -13,7 +13,7 @@ use Qti3\Shared\Model\QtiElement;
  * of choices to the candidate inline, embedded in a surrounding run of content,
  * from which a single choice must be selected (typically rendered as a drop-down).
  */
-class InlineChoiceInteraction extends AbstractInteractionElement
+class InlineChoiceInteraction extends AbstractSharedAttributeElement
 {
     /**
      * @param array<int,InlineChoice> $choices

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/Label.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/Label.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 
 /**
  * The optional qti-label of an {@see InlineChoiceInteraction}: a run of inline
  * content that labels the interaction. It carries no attributes of its own
  * beyond the shared ones.
  */
-class Label extends AbstractSharedAttributeElement
+class Label extends AbstractBaseSequenceElement
 {
     public function __construct(
         public ContentNodeCollection $content,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -25,7 +25,7 @@ class Label extends AbstractSharedAttributeElement
     public function attributes(): array
     {
         return [
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/Label.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/Label.php
@@ -2,19 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Qti3\AssessmentItem\Model\Interaction\HottextInteraction;
+namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
 use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
-use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
+use Qti3\Shared\Model\SharedAttributes;
 
-class Hottext extends AbstractInteractionElement
+/**
+ * The optional qti-label of an {@see InlineChoiceInteraction}: a run of inline
+ * content that labels the interaction. It carries no attributes of its own
+ * beyond the shared ones.
+ */
+class Label extends AbstractInteractionElement
 {
     public function __construct(
-        public string $identifier,
         public ContentNodeCollection $content,
-        public ?string $templateIdentifier = null,
-        public string $showHide = 'show',
         SharedAttributes $attributes = new SharedAttributes(),
     ) {
         parent::__construct($attributes);
@@ -23,9 +25,6 @@ class Hottext extends AbstractInteractionElement
     public function attributes(): array
     {
         return [
-            'identifier' => $this->identifier,
-            'template-identifier' => $this->templateIdentifier,
-            'show-hide' => $this->showHide,
             ...$this->sharedAttributes(),
         ];
     }

--- a/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/Label.php
+++ b/src/AssessmentItem/Model/Interaction/InlineChoiceInteraction/Label.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\ContentNodeCollection;
 use Qti3\Shared\Model\SharedAttributes;
 
@@ -13,7 +13,7 @@ use Qti3\Shared\Model\SharedAttributes;
  * content that labels the interaction. It carries no attributes of its own
  * beyond the shared ones.
  */
-class Label extends AbstractInteractionElement
+class Label extends AbstractSharedAttributeElement
 {
     public function __construct(
         public ContentNodeCollection $content,

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteraction.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
-use Qti3\Shared\Model\QtiElement;
 
 /**
- * The text entry interaction allows a candidate to supply a text string for a response.
+ * The match interaction presents two sets of choices and requires the candidate
+ * to create associations between them.
  */
-class MatchInteraction extends QtiElement
+class MatchInteraction extends AbstractInteractionElement
 {
     public function __construct(
         public SimpleMatchSet $simpleMatchSet1,
@@ -19,8 +21,11 @@ class MatchInteraction extends QtiElement
         public string $responseIdentifier = 'RESPONSE',
         public bool $shuffle = false,
         public ?int $maxAssociations = null,
-        public ?string $class = null,
-    ) {}
+        public ?int $minAssociations = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -28,7 +33,8 @@ class MatchInteraction extends QtiElement
             'response-identifier' => $this->responseIdentifier,
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'max-associations' => $this->maxAssociations === null ? null : (string) $this->maxAssociations,
-            'class' => $this->class,
+            'min-associations' => $this->minAssociations === null ? null : (string) $this->minAssociations,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteraction.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 
 /**
  * The match interaction presents two sets of choices and requires the candidate
  * to create associations between them.
  */
-class MatchInteraction extends AbstractSharedAttributeElement
+class MatchInteraction extends AbstractBaseSequenceElement
 {
     public function __construct(
         public SimpleMatchSet $simpleMatchSet1,
@@ -22,7 +22,7 @@ class MatchInteraction extends AbstractSharedAttributeElement
         public bool $shuffle = false,
         public ?int $maxAssociations = null,
         public ?int $minAssociations = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -34,7 +34,7 @@ class MatchInteraction extends AbstractSharedAttributeElement
             'shuffle' => $this->shuffle ? 'true' : 'false',
             'max-associations' => $this->maxAssociations === null ? null : (string) $this->maxAssociations,
             'min-associations' => $this->minAssociations === null ? null : (string) $this->minAssociations,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 
@@ -12,7 +12,7 @@ use Qti3\AssessmentItem\Model\Interaction\Prompt;
  * The match interaction presents two sets of choices and requires the candidate
  * to create associations between them.
  */
-class MatchInteraction extends AbstractInteractionElement
+class MatchInteraction extends AbstractSharedAttributeElement
 {
     public function __construct(
         public SimpleMatchSet $simpleMatchSet1,

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-class SimpleAssociableChoice extends AbstractInteractionElement
+class SimpleAssociableChoice extends AbstractSharedAttributeElement
 {
     public function __construct(
         public string $identifier,

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
 
-class SimpleAssociableChoice extends AbstractSharedAttributeElement
+class SimpleAssociableChoice extends AbstractBaseSequenceElement
 {
     public function __construct(
         public string $identifier,
@@ -19,7 +19,7 @@ class SimpleAssociableChoice extends AbstractSharedAttributeElement
         public ?string $templateIdentifier = null,
         public ?string $showHide = null,
         public ?string $matchGroup = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -34,7 +34,7 @@ class SimpleAssociableChoice extends AbstractSharedAttributeElement
             'template-identifier' => $this->templateIdentifier,
             'show-hide' => $this->showHide,
             'match-group' => $this->matchGroup,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
@@ -17,7 +17,7 @@ class SimpleAssociableChoice extends AbstractBaseSequenceElement
         public ?int $matchMin = null,
         public bool $fixed = false,
         public ?string $templateIdentifier = null,
-        public ?string $showHide = null,
+        public string $showHide = 'show',
         public ?string $matchGroup = null,
         BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoice.php
@@ -4,22 +4,37 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\QtiElement;
 
-class SimpleAssociableChoice extends QtiElement
+class SimpleAssociableChoice extends AbstractInteractionElement
 {
     public function __construct(
         public string $identifier,
         public ContentNodeCollection $content,
         public int $matchMax = 1,
-    ) {}
+        public ?int $matchMin = null,
+        public bool $fixed = false,
+        public ?string $templateIdentifier = null,
+        public ?string $showHide = null,
+        public ?string $matchGroup = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'identifier' => $this->identifier,
             'match-max' => (string) $this->matchMax,
+            'match-min' => $this->matchMin === null ? null : (string) $this->matchMin,
+            'fixed' => $this->fixed ? 'true' : null,
+            'template-identifier' => $this->templateIdentifier,
+            'show-hide' => $this->showHide,
+            'match-group' => $this->matchGroup,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleMatchSet.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleMatchSet.php
@@ -4,14 +4,27 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\Shared\Model\QtiElement;
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 
-class SimpleMatchSet extends QtiElement
+class SimpleMatchSet extends AbstractInteractionElement
 {
+    /**
+     * @param array<int,SimpleAssociableChoice> $choices
+     */
     public function __construct(
-        /** @var array<int,SimpleAssociableChoice> */
         public array $choices,
-    ) {}
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
+
+    public function attributes(): array
+    {
+        return [
+            ...$this->sharedAttributes(),
+        ];
+    }
 
     public function children(): array
     {

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleMatchSet.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleMatchSet.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 
-class SimpleMatchSet extends AbstractSharedAttributeElement
+class SimpleMatchSet extends AbstractBaseSequenceElement
 {
     /**
      * @param array<int,SimpleAssociableChoice> $choices
      */
     public function __construct(
         public array $choices,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -22,7 +22,7 @@ class SimpleMatchSet extends AbstractSharedAttributeElement
     public function attributes(): array
     {
         return [
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleMatchSet.php
+++ b/src/AssessmentItem/Model/Interaction/MatchInteraction/SimpleMatchSet.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\MatchInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 
-class SimpleMatchSet extends AbstractInteractionElement
+class SimpleMatchSet extends AbstractSharedAttributeElement
 {
     /**
      * @param array<int,SimpleAssociableChoice> $choices

--- a/src/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteraction.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\OrderInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
 use Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction\SimpleChoice;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 
 /**
  * The order interaction requires the candidate to reorder a set of choices.
  */
-class OrderInteraction extends AbstractSharedAttributeElement
+class OrderInteraction extends AbstractBaseSequenceElement
 {
     /**
      * @param array<int,SimpleChoice> $choices
@@ -25,7 +25,7 @@ class OrderInteraction extends AbstractSharedAttributeElement
         public ?Prompt $prompt = null,
         public ?int $minChoices = null,
         public ?int $maxChoices = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -38,7 +38,7 @@ class OrderInteraction extends AbstractSharedAttributeElement
             'shuffle' => $this->shuffle === null ? null : ($this->shuffle ? 'true' : 'false'),
             'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'max-choices' => $this->maxChoices === null ? null : (string) $this->maxChoices,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteraction.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\OrderInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
 use Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction\SimpleChoice;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
-use Qti3\Shared\Model\QtiElement;
 
 /**
- * The text entry interaction allows a candidate to supply a text string for a response.
+ * The order interaction requires the candidate to reorder a set of choices.
  */
-class OrderInteraction extends QtiElement
+class OrderInteraction extends AbstractInteractionElement
 {
     /**
      * @param array<int,SimpleChoice> $choices
@@ -22,7 +23,12 @@ class OrderInteraction extends QtiElement
         public Orientation $orientation = Orientation::VERTICAL,
         public ?bool $shuffle = null,
         public ?Prompt $prompt = null,
-    ) {}
+        public ?int $minChoices = null,
+        public ?int $maxChoices = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
@@ -30,6 +36,9 @@ class OrderInteraction extends QtiElement
             'response-identifier' => $this->responseIdentifier,
             'orientation' => $this->orientation->value,
             'shuffle' => $this->shuffle === null ? null : ($this->shuffle ? 'true' : 'false'),
+            'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
+            'max-choices' => $this->maxChoices === null ? null : (string) $this->maxChoices,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\OrderInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction\SimpleChoice;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
@@ -12,7 +12,7 @@ use Qti3\AssessmentItem\Model\Interaction\Prompt;
 /**
  * The order interaction requires the candidate to reorder a set of choices.
  */
-class OrderInteraction extends AbstractInteractionElement
+class OrderInteraction extends AbstractSharedAttributeElement
 {
     /**
      * @param array<int,SimpleChoice> $choices

--- a/src/AssessmentItem/Model/Interaction/Prompt.php
+++ b/src/AssessmentItem/Model/Interaction/Prompt.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction;
 
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\ContentNodeCollection;
 use Qti3\Shared\Model\SharedAttributes;
 
-class Prompt extends AbstractInteractionElement
+class Prompt extends AbstractSharedAttributeElement
 {
     public function __construct(
         public ContentNodeCollection $content,

--- a/src/AssessmentItem/Model/Interaction/Prompt.php
+++ b/src/AssessmentItem/Model/Interaction/Prompt.php
@@ -5,13 +5,23 @@ declare(strict_types=1);
 namespace Qti3\AssessmentItem\Model\Interaction;
 
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\QtiElement;
+use Qti3\Shared\Model\SharedAttributes;
 
-class Prompt extends QtiElement
+class Prompt extends AbstractInteractionElement
 {
     public function __construct(
         public ContentNodeCollection $content,
-    ) {}
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
+
+    public function attributes(): array
+    {
+        return [
+            ...$this->sharedAttributes(),
+        ];
+    }
 
     public function children(): array
     {

--- a/src/AssessmentItem/Model/Interaction/Prompt.php
+++ b/src/AssessmentItem/Model/Interaction/Prompt.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
 use Qti3\Shared\Model\ContentNodeCollection;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 
-class Prompt extends AbstractSharedAttributeElement
+class Prompt extends AbstractBaseSequenceElement
 {
     public function __construct(
         public ContentNodeCollection $content,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -20,7 +20,7 @@ class Prompt extends AbstractSharedAttributeElement
     public function attributes(): array
     {
         return [
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteraction.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\SelectPointInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\HTMLTag;
 
 /**
  * The select point interaction requires the candidate to select points on an image.
  */
-class SelectPointInteraction extends AbstractSharedAttributeElement
+class SelectPointInteraction extends AbstractBaseSequenceElement
 {
     public function __construct(
         public HTMLTag $image,
@@ -20,7 +20,7 @@ class SelectPointInteraction extends AbstractSharedAttributeElement
         public ?Prompt $prompt = null,
         public string $responseIdentifier = 'RESPONSE',
         public ?int $minChoices = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -31,7 +31,7 @@ class SelectPointInteraction extends AbstractSharedAttributeElement
             'max-choices' => (string) $this->maxChoices,
             'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'response-identifier' => $this->responseIdentifier,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteraction.php
@@ -4,27 +4,34 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\SelectPointInteraction;
 
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\HTMLTag;
-use Qti3\Shared\Model\QtiElement;
 
 /**
  * The select point interaction requires the candidate to select points on an image.
  */
-class SelectPointInteraction extends QtiElement
+class SelectPointInteraction extends AbstractInteractionElement
 {
     public function __construct(
         public HTMLTag $image,
         public int $maxChoices,
         public ?Prompt $prompt = null,
         public string $responseIdentifier = 'RESPONSE',
-    ) {}
+        public ?int $minChoices = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'max-choices' => (string) $this->maxChoices,
+            'min-choices' => $this->minChoices === null ? null : (string) $this->minChoices,
             'response-identifier' => $this->responseIdentifier,
+            ...$this->sharedAttributes(),
         ];
     }
 

--- a/src/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\SelectPointInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 use Qti3\AssessmentItem\Model\Interaction\Prompt;
 use Qti3\Shared\Model\HTMLTag;
@@ -12,7 +12,7 @@ use Qti3\Shared\Model\HTMLTag;
 /**
  * The select point interaction requires the candidate to select points on an image.
  */
-class SelectPointInteraction extends AbstractInteractionElement
+class SelectPointInteraction extends AbstractSharedAttributeElement
 {
     public function __construct(
         public HTMLTag $image,

--- a/src/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteraction.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\TextEntryInteraction;
 
-use Qti3\Shared\Model\AbstractSharedAttributeElement;
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\AbstractBaseSequenceElement;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 
 /**
  * The text entry interaction allows a candidate to supply a text string for a response.
  */
-class TextEntryInteraction extends AbstractSharedAttributeElement
+class TextEntryInteraction extends AbstractBaseSequenceElement
 {
     public function __construct(
         public string $responseIdentifier = 'RESPONSE',
@@ -20,7 +20,7 @@ class TextEntryInteraction extends AbstractSharedAttributeElement
         public ?string $patternMask = null,
         public ?string $placeholderText = null,
         public ?string $format = null,
-        SharedAttributes $attributes = new SharedAttributes(),
+        BaseSequenceAttributes $attributes = new BaseSequenceAttributes(),
     ) {
         parent::__construct($attributes);
     }
@@ -35,7 +35,7 @@ class TextEntryInteraction extends AbstractSharedAttributeElement
             'pattern-mask' => $this->patternMask,
             'placeholder-text' => $this->placeholderText,
             'format' => $this->format,
-            ...$this->sharedAttributes(),
+            ...$this->baseSequenceAttributes(),
         ];
     }
 }

--- a/src/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteraction.php
@@ -4,21 +4,38 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\TextEntryInteraction;
 
-use Qti3\Shared\Model\QtiElement;
+use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\SharedAttributes;
 
 /**
  * The text entry interaction allows a candidate to supply a text string for a response.
  */
-class TextEntryInteraction extends QtiElement
+class TextEntryInteraction extends AbstractInteractionElement
 {
     public function __construct(
         public string $responseIdentifier = 'RESPONSE',
-    ) {}
+        public ?int $base = null,
+        public ?string $stringIdentifier = null,
+        public ?int $expectedLength = null,
+        public ?string $patternMask = null,
+        public ?string $placeholderText = null,
+        public ?string $format = null,
+        SharedAttributes $attributes = new SharedAttributes(),
+    ) {
+        parent::__construct($attributes);
+    }
 
     public function attributes(): array
     {
         return [
             'response-identifier' => $this->responseIdentifier,
+            'base' => $this->base === null ? null : (string) $this->base,
+            'string-identifier' => $this->stringIdentifier,
+            'expected-length' => $this->expectedLength === null ? null : (string) $this->expectedLength,
+            'pattern-mask' => $this->patternMask,
+            'placeholder-text' => $this->placeholderText,
+            'format' => $this->format,
+            ...$this->sharedAttributes(),
         ];
     }
 }

--- a/src/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteraction.php
+++ b/src/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteraction.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Model\Interaction\TextEntryInteraction;
 
-use Qti3\AssessmentItem\Model\Interaction\AbstractInteractionElement;
+use Qti3\Shared\Model\AbstractSharedAttributeElement;
 use Qti3\Shared\Model\SharedAttributes;
 
 /**
  * The text entry interaction allows a candidate to supply a text string for a response.
  */
-class TextEntryInteraction extends AbstractInteractionElement
+class TextEntryInteraction extends AbstractSharedAttributeElement
 {
     public function __construct(
         public string $responseIdentifier = 'RESPONSE',

--- a/src/AssessmentItem/Service/AssessmentItemValidator.php
+++ b/src/AssessmentItem/Service/AssessmentItemValidator.php
@@ -20,7 +20,8 @@ use RuntimeException;
  * {@see \Qti3\Package\Validator\ImsGlobalQtiSyntaxValidator}).
  *
  * Structural validation also works for interaction types the typed item parser
- * cannot handle (e.g. inline-choice), which is why it is string/DOM based.
+ * cannot handle (e.g. custom or upload interactions), which is why it is
+ * string/DOM based.
  */
 final readonly class AssessmentItemValidator implements IAssessmentItemValidator
 {

--- a/src/AssessmentItem/Service/Parser/AbstractParser.php
+++ b/src/AssessmentItem/Service/Parser/AbstractParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Service\Parser;
 
+use Qti3\Shared\Model\SharedAttributes;
 use Qti3\Shared\Collection\StringCollection;
 use DOMAttr;
 use DOMElement;
@@ -11,6 +12,11 @@ use DOMNode;
 
 abstract class AbstractParser
 {
+    /**
+     * @var list<string>
+     */
+    protected const array SHARED_GLOBAL_ATTRIBUTES = ['id', 'class', 'xml:lang', 'label', 'dir'];
+
     protected function validateTag(DOMElement|DOMNode|null $element, string $tagName): void
     {
         if (!$element instanceof DOMElement) {
@@ -33,6 +39,63 @@ abstract class AbstractParser
         }
 
         return $children;
+    }
+
+    /**
+     * @param list<string> $consumed       element-specific attribute names already read
+     * @param list<string> $allowedGlobals HTML-ish global attribute names permitted here
+     * @param bool          $allowAria      whether role/aria-* are permitted (false for
+     *                                      elements that do not extend the ARIA base)
+     */
+    protected function readSharedAttributes(
+        DOMElement $element,
+        array $consumed,
+        array $allowedGlobals = self::SHARED_GLOBAL_ATTRIBUTES,
+        bool $allowAria = true,
+    ): SharedAttributes {
+        $globals = ['id' => null, 'class' => null, 'xml:lang' => null, 'label' => null, 'dir' => null];
+        $role = null;
+        $aria = [];
+        $data = [];
+
+        foreach ($element->attributes as $attribute) {
+            if (!$attribute instanceof DOMAttr || $this->isNamespaceAttribute($attribute)) {
+                continue;
+            }
+            $name = $attribute->nodeName;
+            $value = $attribute->nodeValue ?? '';
+
+            if (in_array($name, $consumed, true)) {
+                continue;
+            }
+            if (str_starts_with($name, 'data-')) {
+                $data[$name] = $value; // open extension family (dataExtension / xs:anyAttribute)
+                continue;
+            }
+            if ($allowAria && $name === 'role') {
+                $role = $value;
+                continue;
+            }
+            if ($allowAria && str_starts_with($name, 'aria-')) {
+                $aria[$name] = $value;
+                continue;
+            }
+            if (!in_array($name, $allowedGlobals, true)) {
+                continue; // not permitted by the spec for this element: drop it
+            }
+            $globals[$name] = $value;
+        }
+
+        return new SharedAttributes(
+            $globals['id'],
+            $globals['class'],
+            $globals['xml:lang'],
+            $globals['label'],
+            $globals['dir'],
+            $role,
+            $aria,
+            $data,
+        );
     }
 
     /**
@@ -88,7 +151,7 @@ abstract class AbstractParser
         return '/' . implode('/', array_reverse($segments));
     }
 
-    private function isNamespaceAttribute(DOMAttr $attribute): bool
+    protected function isNamespaceAttribute(DOMAttr $attribute): bool
     {
         return $attribute->nodeName === 'xmlns'
             || str_starts_with($attribute->nodeName, 'xmlns:')

--- a/src/AssessmentItem/Service/Parser/AbstractParser.php
+++ b/src/AssessmentItem/Service/Parser/AbstractParser.php
@@ -17,6 +17,62 @@ abstract class AbstractParser
      */
     protected const array SHARED_GLOBAL_ATTRIBUTES = ['id', 'class', 'xml:lang', 'label', 'dir'];
 
+    /**
+     * The ARIA attributes enumerated by ARIABaseDType in the QTI 3.0 ASI schema
+     * (imsqti_asiv3p0_v1p0.xsd). `aria-*` attributes outside this set are not
+     * spec-permitted and are dropped rather than carried through.
+     *
+     * @var list<string>
+     */
+    protected const array ARIA_ATTRIBUTES = [
+        'aria-activedescendant',
+        'aria-atomic',
+        'aria-autocomplete',
+        'aria-busy',
+        'aria-checked',
+        'aria-colcount',
+        'aria-colindex',
+        'aria-colspan',
+        'aria-controls',
+        'aria-current',
+        'aria-describedby',
+        'aria-details',
+        'aria-disabled',
+        'aria-errormessage',
+        'aria-expanded',
+        'aria-flowto',
+        'aria-haspopup',
+        'aria-hidden',
+        'aria-invalid',
+        'aria-keyshortcuts',
+        'aria-label',
+        'aria-labelledby',
+        'aria-level',
+        'aria-live',
+        'aria-modal',
+        'aria-multiline',
+        'aria-multiselectable',
+        'aria-orientation',
+        'aria-owns',
+        'aria-placeholder',
+        'aria-posinset',
+        'aria-pressed',
+        'aria-readonly',
+        'aria-relevant',
+        'aria-required',
+        'aria-roledescription',
+        'aria-rowcount',
+        'aria-rowindex',
+        'aria-rowspan',
+        'aria-selected',
+        'aria-setsize',
+        'aria-sort',
+        'aria-valuemax',
+        'aria-valuemin',
+        'aria-valuenow',
+        'aria-valuetext',
+    ];
+
     protected function validateTag(DOMElement|DOMNode|null $element, string $tagName): void
     {
         if (!$element instanceof DOMElement) {
@@ -77,8 +133,10 @@ abstract class AbstractParser
                 continue;
             }
             if ($allowAria && str_starts_with($name, 'aria-')) {
-                $aria[$name] = $value;
-                continue;
+                if (in_array($name, self::ARIA_ATTRIBUTES, true)) {
+                    $aria[$name] = $value; // enumerated by ARIABaseDType
+                }
+                continue; // unknown aria-* is not spec-permitted: drop it
             }
             if (!in_array($name, $allowedGlobals, true)) {
                 continue; // not permitted by the spec for this element: drop it

--- a/src/AssessmentItem/Service/Parser/AbstractParser.php
+++ b/src/AssessmentItem/Service/Parser/AbstractParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qti3\AssessmentItem\Service\Parser;
 
-use Qti3\Shared\Model\SharedAttributes;
+use Qti3\Shared\Model\BaseSequenceAttributes;
 use Qti3\Shared\Collection\StringCollection;
 use DOMAttr;
 use DOMElement;
@@ -103,12 +103,12 @@ abstract class AbstractParser
      * @param bool          $allowAria      whether role/aria-* are permitted (false for
      *                                      elements that do not extend the ARIA base)
      */
-    protected function readSharedAttributes(
+    protected function readBaseSequenceAttributes(
         DOMElement $element,
         array $consumed,
         array $allowedGlobals = self::SHARED_GLOBAL_ATTRIBUTES,
         bool $allowAria = true,
-    ): SharedAttributes {
+    ): BaseSequenceAttributes {
         $globals = ['id' => null, 'class' => null, 'xml:lang' => null, 'label' => null, 'dir' => null];
         $role = null;
         $aria = [];
@@ -144,7 +144,7 @@ abstract class AbstractParser
             $globals[$name] = $value;
         }
 
-        return new SharedAttributes(
+        return new BaseSequenceAttributes(
             $globals['id'],
             $globals['class'],
             $globals['xml:lang'],

--- a/src/AssessmentItem/Service/Parser/InteractionParser.php
+++ b/src/AssessmentItem/Service/Parser/InteractionParser.php
@@ -21,6 +21,7 @@ use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\Hottext;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\HottextInteraction;
 use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoice;
 use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoiceInteraction;
+use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\Label;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\MatchInteraction;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\SimpleAssociableChoice;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\SimpleMatchSet;
@@ -62,6 +63,8 @@ class InteractionParser extends AbstractParser
         $shuffle = strtolower($element->getAttribute('shuffle')) === 'true';
         $maxChoicesAttr = $element->getAttribute('max-choices');
         $maxChoices = $maxChoicesAttr !== '' ? (int) $maxChoicesAttr : 1;
+        $minChoices = $this->intAttributeOrNull($element, 'min-choices');
+        $orientation = $this->orientationOrNull($element);
 
         $prompt = $this->findPrompt($element);
 
@@ -72,13 +75,18 @@ class InteractionParser extends AbstractParser
             }
         }
 
-        return new ChoiceInteraction($choices, $responseIdentifier, $prompt, $shuffle, $maxChoices);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'max-choices', 'min-choices', 'orientation']);
+
+        return new ChoiceInteraction($choices, $responseIdentifier, $prompt, $shuffle, $maxChoices, $minChoices, $orientation, $shared);
     }
 
     private function parseSimpleChoice(DOMElement $element): SimpleChoice
     {
         $this->validateTag($element, SimpleChoice::qtiTagName());
         $identifier = $element->getAttribute('identifier');
+        $fixed = strtolower($element->getAttribute('fixed')) === 'true';
+        $templateIdentifier = $element->getAttribute('template-identifier') ?: null;
+        $showHide = $element->getAttribute('show-hide') ?: 'show';
         $content = $this->parseContentChildren($element);
 
         $feedback = null;
@@ -88,7 +96,9 @@ class InteractionParser extends AbstractParser
             }
         }
 
-        return new SimpleChoice($identifier, $content, $feedback);
+        $shared = $this->readSharedAttributes($element, ['identifier', 'fixed', 'template-identifier', 'show-hide']);
+
+        return new SimpleChoice($identifier, $content, $feedback, $fixed, $templateIdentifier, $showHide, $shared);
     }
 
     private function parseFeedbackInline(DOMElement $element): FeedbackInline
@@ -107,7 +117,21 @@ class InteractionParser extends AbstractParser
     {
         $this->validateTag($element, TextEntryInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
-        return new TextEntryInteraction($responseIdentifier);
+        $shared = $this->readSharedAttributes($element, [
+            'response-identifier', 'base', 'string-identifier', 'expected-length',
+            'pattern-mask', 'placeholder-text', 'format',
+        ]);
+
+        return new TextEntryInteraction(
+            $responseIdentifier,
+            $this->intAttributeOrNull($element, 'base'),
+            $element->getAttribute('string-identifier') ?: null,
+            $this->intAttributeOrNull($element, 'expected-length'),
+            $element->getAttribute('pattern-mask') ?: null,
+            $element->getAttribute('placeholder-text') ?: null,
+            $element->getAttribute('format') ?: null,
+            $shared,
+        );
     }
 
     private function parseExtendedTextInteraction(DOMElement $element): ExtendedTextInteraction
@@ -115,7 +139,25 @@ class InteractionParser extends AbstractParser
         $this->validateTag($element, ExtendedTextInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $prompt = $this->findPrompt($element);
-        return new ExtendedTextInteraction($responseIdentifier, $prompt);
+        $shared = $this->readSharedAttributes($element, [
+            'response-identifier', 'base', 'string-identifier', 'expected-length', 'pattern-mask',
+            'placeholder-text', 'max-strings', 'min-strings', 'expected-lines', 'format',
+        ]);
+
+        return new ExtendedTextInteraction(
+            $responseIdentifier,
+            $prompt,
+            $this->intAttributeOrNull($element, 'base'),
+            $element->getAttribute('string-identifier') ?: null,
+            $this->intAttributeOrNull($element, 'expected-length'),
+            $element->getAttribute('pattern-mask') ?: null,
+            $element->getAttribute('placeholder-text') ?: null,
+            $this->intAttributeOrNull($element, 'max-strings'),
+            $this->intAttributeOrNull($element, 'min-strings'),
+            $this->intAttributeOrNull($element, 'expected-lines'),
+            $element->getAttribute('format') ?: null,
+            $shared,
+        );
     }
 
     private function parseGapMatchInteraction(DOMElement $element): GapMatchInteraction
@@ -128,6 +170,8 @@ class InteractionParser extends AbstractParser
         $prompt = $this->findPrompt($element);
 
         $content = $this->parseContentChildren($element);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'max-associations', 'min-associations']);
+
         return new GapMatchInteraction(
             $content,
             $responseIdentifier,
@@ -135,6 +179,7 @@ class InteractionParser extends AbstractParser
             $shuffle,
             $maxAssoc !== '' ? (int) $maxAssoc : 0,
             $minAssoc !== '' ? (int) $minAssoc : null,
+            $shared,
         );
     }
 
@@ -143,6 +188,7 @@ class InteractionParser extends AbstractParser
         $this->validateTag($element, HotspotInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $maxChoices = (int) ($element->getAttribute('max-choices') ?: '0');
+        $minChoices = $this->intAttributeOrNull($element, 'min-choices');
 
         $image = null;
         $choices = [];
@@ -151,10 +197,7 @@ class InteractionParser extends AbstractParser
                 $image = $this->parseHtmlElement($child);
             }
             if ($child->nodeName === HotspotChoice::qtiTagName()) {
-                $shapeName = $child->getAttribute('shape') ?: 'default';
-                $coords = $child->getAttribute('coords') ?: '';
-                $shape = ShapeFactory::create($shapeName, $coords);
-                $choices[] = new HotspotChoice($shape, $child->getAttribute('identifier'));
+                $choices[] = $this->parseHotspotChoice($child);
             }
         }
 
@@ -162,7 +205,26 @@ class InteractionParser extends AbstractParser
             throw new ParseError('HotspotInteraction must contain an img element');
         }
 
-        return new HotspotInteraction($image, $choices, $maxChoices, $responseIdentifier);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
+
+        return new HotspotInteraction($image, $choices, $maxChoices, $responseIdentifier, $minChoices, $shared);
+    }
+
+    private function parseHotspotChoice(DOMElement $element): HotspotChoice
+    {
+        $shapeName = $element->getAttribute('shape') ?: 'default';
+        $coords = $element->getAttribute('coords') ?: '';
+        $shape = ShapeFactory::create($shapeName, $coords);
+        $shared = $this->readSharedAttributes($element, ['shape', 'coords', 'identifier', 'template-identifier', 'show-hide', 'hotspot-label']);
+
+        return new HotspotChoice(
+            $shape,
+            $element->getAttribute('identifier'),
+            $element->getAttribute('template-identifier') ?: null,
+            $element->getAttribute('show-hide') ?: 'show',
+            $element->getAttribute('hotspot-label') ?: null,
+            $shared,
+        );
     }
 
     private function parseHottextInteraction(DOMElement $element): HottextInteraction
@@ -170,8 +232,11 @@ class InteractionParser extends AbstractParser
         $this->validateTag($element, HottextInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $maxChoices = (int) ($element->getAttribute('max-choices') ?: '0');
+        $minChoices = $this->intAttributeOrNull($element, 'min-choices');
         $content = $this->parseContentChildren($element);
-        return new HottextInteraction($maxChoices, $content, $responseIdentifier);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
+
+        return new HottextInteraction($maxChoices, $content, $responseIdentifier, $minChoices, $shared);
     }
 
     private function parseInlineChoiceInteraction(DOMElement $element): InlineChoiceInteraction
@@ -180,15 +245,22 @@ class InteractionParser extends AbstractParser
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $shuffle = strtolower($element->getAttribute('shuffle')) === 'true';
         $required = strtolower($element->getAttribute('required')) === 'true';
+        $minChoices = $this->intAttributeOrNull($element, 'min-choices');
 
         $choices = [];
+        $label = null;
         foreach ($this->getChildren($element) as $child) {
             if ($child->nodeName === InlineChoice::qtiTagName()) {
                 $choices[] = $this->parseInlineChoice($child);
             }
+            if ($child->nodeName === Label::qtiTagName()) {
+                $label = new Label($this->parseContentChildren($child), $this->readSharedAttributes($child, []));
+            }
         }
 
-        return new InlineChoiceInteraction($choices, $responseIdentifier, $shuffle, $required);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'required', 'min-choices']);
+
+        return new InlineChoiceInteraction($choices, $responseIdentifier, $shuffle, $required, $minChoices, $label, $shared);
     }
 
     private function parseInlineChoice(DOMElement $element): InlineChoice
@@ -199,8 +271,9 @@ class InteractionParser extends AbstractParser
         $templateIdentifier = $element->getAttribute('template-identifier') ?: null;
         $showHide = $element->getAttribute('show-hide') ?: 'show';
         $content = $this->parseContentChildren($element);
+        $shared = $this->readSharedAttributes($element, ['identifier', 'fixed', 'template-identifier', 'show-hide']);
 
-        return new InlineChoice($identifier, $content, $fixed, $templateIdentifier, $showHide);
+        return new InlineChoice($identifier, $content, $fixed, $templateIdentifier, $showHide, $shared);
     }
 
     private function parseMatchInteraction(DOMElement $element): MatchInteraction
@@ -208,9 +281,8 @@ class InteractionParser extends AbstractParser
         $this->validateTag($element, MatchInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $shuffle = strtolower($element->getAttribute('shuffle')) === 'true';
-        $maxAssocAttr = $element->getAttribute('max-associations');
-        $maxAssociations = $maxAssocAttr !== '' ? (int) $maxAssocAttr : null;
-        $class = $element->getAttribute('class') ?: null;
+        $maxAssociations = $this->intAttributeOrNull($element, 'max-associations');
+        $minAssociations = $this->intAttributeOrNull($element, 'min-associations');
         $prompt = $this->findPrompt($element);
 
         $sets = [];
@@ -222,7 +294,9 @@ class InteractionParser extends AbstractParser
         $set1 = $sets[0] ?? new SimpleMatchSet([]);
         $set2 = $sets[1] ?? new SimpleMatchSet([]);
 
-        return new MatchInteraction($set1, $set2, $prompt, $responseIdentifier, $shuffle, $maxAssociations, $class);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'max-associations', 'min-associations']);
+
+        return new MatchInteraction($set1, $set2, $prompt, $responseIdentifier, $shuffle, $maxAssociations, $minAssociations, $shared);
     }
 
     private function parseSimpleMatchSet(DOMElement $element): SimpleMatchSet
@@ -231,12 +305,33 @@ class InteractionParser extends AbstractParser
         $choices = [];
         foreach ($this->getChildren($element) as $child) {
             if ($child->nodeName === SimpleAssociableChoice::qtiTagName()) {
-                $identifier = $child->getAttribute('identifier');
-                $content = $this->parseContentChildren($child);
-                $choices[] = new SimpleAssociableChoice($identifier, $content);
+                $choices[] = $this->parseSimpleAssociableChoice($child);
             }
         }
-        return new SimpleMatchSet($choices);
+
+        // A qti-simple-match-set only permits id (plus data-*); it does not extend the ARIA base.
+        $shared = $this->readSharedAttributes($element, [], ['id'], allowAria: false);
+
+        return new SimpleMatchSet($choices, $shared);
+    }
+
+    private function parseSimpleAssociableChoice(DOMElement $element): SimpleAssociableChoice
+    {
+        $matchMaxAttr = $element->getAttribute('match-max');
+        $content = $this->parseContentChildren($element);
+        $shared = $this->readSharedAttributes($element, ['identifier', 'match-max', 'match-min', 'fixed', 'template-identifier', 'show-hide', 'match-group']);
+
+        return new SimpleAssociableChoice(
+            $element->getAttribute('identifier'),
+            $content,
+            $matchMaxAttr !== '' ? (int) $matchMaxAttr : 1,
+            $this->intAttributeOrNull($element, 'match-min'),
+            strtolower($element->getAttribute('fixed')) === 'true',
+            $element->getAttribute('template-identifier') ?: null,
+            $element->getAttribute('show-hide') ?: null,
+            $element->getAttribute('match-group') ?: null,
+            $shared,
+        );
     }
 
     private function parseOrderInteraction(DOMElement $element): OrderInteraction
@@ -246,6 +341,7 @@ class InteractionParser extends AbstractParser
         $shuffle = strtolower($element->getAttribute('shuffle')) === 'true';
         $orientationAttr = $element->getAttribute('orientation') ?: Orientation::VERTICAL->value;
         $orientation = Orientation::from($orientationAttr);
+        $prompt = $this->findPrompt($element);
 
         $choices = [];
         foreach ($this->getChildren($element) as $child) {
@@ -254,7 +350,18 @@ class InteractionParser extends AbstractParser
             }
         }
 
-        return new OrderInteraction($choices, $responseIdentifier, $orientation, $shuffle, null);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'orientation', 'min-choices', 'max-choices']);
+
+        return new OrderInteraction(
+            $choices,
+            $responseIdentifier,
+            $orientation,
+            $shuffle,
+            $prompt,
+            $this->intAttributeOrNull($element, 'min-choices'),
+            $this->intAttributeOrNull($element, 'max-choices'),
+            $shared,
+        );
     }
 
     private function parseSelectPointInteraction(DOMElement $element): SelectPointInteraction
@@ -262,6 +369,7 @@ class InteractionParser extends AbstractParser
         $this->validateTag($element, SelectPointInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $maxChoices = (int) ($element->getAttribute('max-choices') ?: '0');
+        $minChoices = $this->intAttributeOrNull($element, 'min-choices');
         $prompt = $this->findPrompt($element);
 
         $image = null;
@@ -275,7 +383,9 @@ class InteractionParser extends AbstractParser
             throw new ParseError('SelectPointInteraction must contain an img element');
         }
 
-        return new SelectPointInteraction($image, $maxChoices, $prompt, $responseIdentifier);
+        $shared = $this->readSharedAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
+
+        return new SelectPointInteraction($image, $maxChoices, $prompt, $responseIdentifier, $minChoices, $shared);
     }
 
     private function findPrompt(DOMElement $element): ?Prompt
@@ -283,10 +393,22 @@ class InteractionParser extends AbstractParser
         foreach ($this->getChildren($element) as $child) {
             if ($child->nodeName === Prompt::qtiTagName()) {
                 $content = $this->parseContentChildren($child);
-                return new Prompt($content);
+                return new Prompt($content, $this->readSharedAttributes($child, []));
             }
         }
         return null;
+    }
+
+    private function intAttributeOrNull(DOMElement $element, string $name): ?int
+    {
+        $value = $element->getAttribute($name);
+        return $value !== '' ? (int) $value : null;
+    }
+
+    private function orientationOrNull(DOMElement $element): ?Orientation
+    {
+        $value = $element->getAttribute('orientation');
+        return $value !== '' ? Orientation::from($value) : null;
     }
 
     private function parseContentChildren(DOMElement $element): ContentNodeCollection
@@ -317,10 +439,20 @@ class InteractionParser extends AbstractParser
                 return new Hottext(
                     $node->getAttribute('identifier'),
                     $this->parseContentChildren($node),
+                    $node->getAttribute('template-identifier') ?: null,
+                    $node->getAttribute('show-hide') ?: 'show',
+                    $this->readSharedAttributes($node, ['identifier', 'template-identifier', 'show-hide']),
                 );
             }
             if ($node->nodeName === Gap::qtiTagName()) {
-                return new Gap($node->getAttribute('identifier'));
+                return new Gap(
+                    $node->getAttribute('identifier'),
+                    $node->getAttribute('template-identifier') ?: null,
+                    $node->getAttribute('show-hide') ?: 'show',
+                    $node->getAttribute('match-group') ?: null,
+                    strtolower($node->getAttribute('required')) === 'true',
+                    $this->readSharedAttributes($node, ['identifier', 'template-identifier', 'show-hide', 'match-group', 'required']),
+                );
             }
             if ($node->nodeName === GapText::qtiTagName()) {
                 $matchMax = (int) ($node->getAttribute('match-max') ?: '0');
@@ -336,6 +468,7 @@ class InteractionParser extends AbstractParser
                     $matchGroup,
                     $templateIdentifier,
                     $showHide,
+                    $this->readSharedAttributes($node, ['identifier', 'match-max', 'match-min', 'match-group', 'template-identifier', 'show-hide']),
                 );
             }
             if ($node->nodeName === FeedbackInline::qtiTagName()) {

--- a/src/AssessmentItem/Service/Parser/InteractionParser.php
+++ b/src/AssessmentItem/Service/Parser/InteractionParser.php
@@ -75,7 +75,7 @@ class InteractionParser extends AbstractParser
             }
         }
 
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'max-choices', 'min-choices', 'orientation']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'shuffle', 'max-choices', 'min-choices', 'orientation']);
 
         return new ChoiceInteraction($choices, $responseIdentifier, $prompt, $shuffle, $maxChoices, $minChoices, $orientation, $shared);
     }
@@ -96,7 +96,7 @@ class InteractionParser extends AbstractParser
             }
         }
 
-        $shared = $this->readSharedAttributes($element, ['identifier', 'fixed', 'template-identifier', 'show-hide']);
+        $shared = $this->readBaseSequenceAttributes($element, ['identifier', 'fixed', 'template-identifier', 'show-hide']);
 
         return new SimpleChoice($identifier, $content, $feedback, $fixed, $templateIdentifier, $showHide, $shared);
     }
@@ -117,7 +117,7 @@ class InteractionParser extends AbstractParser
     {
         $this->validateTag($element, TextEntryInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
-        $shared = $this->readSharedAttributes($element, [
+        $shared = $this->readBaseSequenceAttributes($element, [
             'response-identifier', 'base', 'string-identifier', 'expected-length',
             'pattern-mask', 'placeholder-text', 'format',
         ]);
@@ -139,7 +139,7 @@ class InteractionParser extends AbstractParser
         $this->validateTag($element, ExtendedTextInteraction::qtiTagName());
         $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
         $prompt = $this->findPrompt($element);
-        $shared = $this->readSharedAttributes($element, [
+        $shared = $this->readBaseSequenceAttributes($element, [
             'response-identifier', 'base', 'string-identifier', 'expected-length', 'pattern-mask',
             'placeholder-text', 'max-strings', 'min-strings', 'expected-lines', 'format',
         ]);
@@ -170,7 +170,7 @@ class InteractionParser extends AbstractParser
         $prompt = $this->findPrompt($element);
 
         $content = $this->parseContentChildren($element);
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'max-associations', 'min-associations']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'shuffle', 'max-associations', 'min-associations']);
 
         return new GapMatchInteraction(
             $content,
@@ -205,7 +205,7 @@ class InteractionParser extends AbstractParser
             throw new ParseError('HotspotInteraction must contain an img element');
         }
 
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
 
         return new HotspotInteraction($image, $choices, $maxChoices, $responseIdentifier, $minChoices, $shared);
     }
@@ -215,7 +215,7 @@ class InteractionParser extends AbstractParser
         $shapeName = $element->getAttribute('shape') ?: 'default';
         $coords = $element->getAttribute('coords') ?: '';
         $shape = ShapeFactory::create($shapeName, $coords);
-        $shared = $this->readSharedAttributes($element, ['shape', 'coords', 'identifier', 'template-identifier', 'show-hide', 'hotspot-label']);
+        $shared = $this->readBaseSequenceAttributes($element, ['shape', 'coords', 'identifier', 'template-identifier', 'show-hide', 'hotspot-label']);
 
         return new HotspotChoice(
             $shape,
@@ -234,7 +234,7 @@ class InteractionParser extends AbstractParser
         $maxChoices = (int) ($element->getAttribute('max-choices') ?: '0');
         $minChoices = $this->intAttributeOrNull($element, 'min-choices');
         $content = $this->parseContentChildren($element);
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
 
         return new HottextInteraction($maxChoices, $content, $responseIdentifier, $minChoices, $shared);
     }
@@ -254,11 +254,11 @@ class InteractionParser extends AbstractParser
                 $choices[] = $this->parseInlineChoice($child);
             }
             if ($child->nodeName === Label::qtiTagName()) {
-                $label = new Label($this->parseContentChildren($child), $this->readSharedAttributes($child, []));
+                $label = new Label($this->parseContentChildren($child), $this->readBaseSequenceAttributes($child, []));
             }
         }
 
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'required', 'min-choices']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'shuffle', 'required', 'min-choices']);
 
         return new InlineChoiceInteraction($choices, $responseIdentifier, $shuffle, $required, $minChoices, $label, $shared);
     }
@@ -271,7 +271,7 @@ class InteractionParser extends AbstractParser
         $templateIdentifier = $element->getAttribute('template-identifier') ?: null;
         $showHide = $element->getAttribute('show-hide') ?: 'show';
         $content = $this->parseContentChildren($element);
-        $shared = $this->readSharedAttributes($element, ['identifier', 'fixed', 'template-identifier', 'show-hide']);
+        $shared = $this->readBaseSequenceAttributes($element, ['identifier', 'fixed', 'template-identifier', 'show-hide']);
 
         return new InlineChoice($identifier, $content, $fixed, $templateIdentifier, $showHide, $shared);
     }
@@ -294,7 +294,7 @@ class InteractionParser extends AbstractParser
         $set1 = $sets[0] ?? new SimpleMatchSet([]);
         $set2 = $sets[1] ?? new SimpleMatchSet([]);
 
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'max-associations', 'min-associations']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'shuffle', 'max-associations', 'min-associations']);
 
         return new MatchInteraction($set1, $set2, $prompt, $responseIdentifier, $shuffle, $maxAssociations, $minAssociations, $shared);
     }
@@ -310,7 +310,7 @@ class InteractionParser extends AbstractParser
         }
 
         // A qti-simple-match-set only permits id (plus data-*); it does not extend the ARIA base.
-        $shared = $this->readSharedAttributes($element, [], ['id'], allowAria: false);
+        $shared = $this->readBaseSequenceAttributes($element, [], ['id'], allowAria: false);
 
         return new SimpleMatchSet($choices, $shared);
     }
@@ -319,7 +319,7 @@ class InteractionParser extends AbstractParser
     {
         $matchMaxAttr = $element->getAttribute('match-max');
         $content = $this->parseContentChildren($element);
-        $shared = $this->readSharedAttributes($element, ['identifier', 'match-max', 'match-min', 'fixed', 'template-identifier', 'show-hide', 'match-group']);
+        $shared = $this->readBaseSequenceAttributes($element, ['identifier', 'match-max', 'match-min', 'fixed', 'template-identifier', 'show-hide', 'match-group']);
 
         return new SimpleAssociableChoice(
             $element->getAttribute('identifier'),
@@ -350,7 +350,7 @@ class InteractionParser extends AbstractParser
             }
         }
 
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'shuffle', 'orientation', 'min-choices', 'max-choices']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'shuffle', 'orientation', 'min-choices', 'max-choices']);
 
         return new OrderInteraction(
             $choices,
@@ -383,7 +383,7 @@ class InteractionParser extends AbstractParser
             throw new ParseError('SelectPointInteraction must contain an img element');
         }
 
-        $shared = $this->readSharedAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
+        $shared = $this->readBaseSequenceAttributes($element, ['response-identifier', 'max-choices', 'min-choices']);
 
         return new SelectPointInteraction($image, $maxChoices, $prompt, $responseIdentifier, $minChoices, $shared);
     }
@@ -393,7 +393,7 @@ class InteractionParser extends AbstractParser
         foreach ($this->getChildren($element) as $child) {
             if ($child->nodeName === Prompt::qtiTagName()) {
                 $content = $this->parseContentChildren($child);
-                return new Prompt($content, $this->readSharedAttributes($child, []));
+                return new Prompt($content, $this->readBaseSequenceAttributes($child, []));
             }
         }
         return null;
@@ -441,7 +441,7 @@ class InteractionParser extends AbstractParser
                     $this->parseContentChildren($node),
                     $node->getAttribute('template-identifier') ?: null,
                     $node->getAttribute('show-hide') ?: 'show',
-                    $this->readSharedAttributes($node, ['identifier', 'template-identifier', 'show-hide']),
+                    $this->readBaseSequenceAttributes($node, ['identifier', 'template-identifier', 'show-hide']),
                 );
             }
             if ($node->nodeName === Gap::qtiTagName()) {
@@ -451,7 +451,7 @@ class InteractionParser extends AbstractParser
                     $node->getAttribute('show-hide') ?: 'show',
                     $node->getAttribute('match-group') ?: null,
                     strtolower($node->getAttribute('required')) === 'true',
-                    $this->readSharedAttributes($node, ['identifier', 'template-identifier', 'show-hide', 'match-group', 'required']),
+                    $this->readBaseSequenceAttributes($node, ['identifier', 'template-identifier', 'show-hide', 'match-group', 'required']),
                 );
             }
             if ($node->nodeName === GapText::qtiTagName()) {
@@ -468,7 +468,7 @@ class InteractionParser extends AbstractParser
                     $matchGroup,
                     $templateIdentifier,
                     $showHide,
-                    $this->readSharedAttributes($node, ['identifier', 'match-max', 'match-min', 'match-group', 'template-identifier', 'show-hide']),
+                    $this->readBaseSequenceAttributes($node, ['identifier', 'match-max', 'match-min', 'match-group', 'template-identifier', 'show-hide']),
                 );
             }
             if ($node->nodeName === FeedbackInline::qtiTagName()) {

--- a/src/AssessmentItem/Service/Parser/InteractionParser.php
+++ b/src/AssessmentItem/Service/Parser/InteractionParser.php
@@ -328,7 +328,7 @@ class InteractionParser extends AbstractParser
             $this->intAttributeOrNull($element, 'match-min'),
             strtolower($element->getAttribute('fixed')) === 'true',
             $element->getAttribute('template-identifier') ?: null,
-            $element->getAttribute('show-hide') ?: null,
+            $element->getAttribute('show-hide') ?: 'show',
             $element->getAttribute('match-group') ?: null,
             $shared,
         );

--- a/src/AssessmentItem/Service/Parser/InteractionParser.php
+++ b/src/AssessmentItem/Service/Parser/InteractionParser.php
@@ -19,6 +19,8 @@ use Qti3\AssessmentItem\Model\Interaction\HotspotInteraction\HotspotChoice;
 use Qti3\AssessmentItem\Model\Interaction\HotspotInteraction\HotspotInteraction;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\Hottext;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\HottextInteraction;
+use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoice;
+use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoiceInteraction;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\MatchInteraction;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\SimpleAssociableChoice;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\SimpleMatchSet;
@@ -44,6 +46,7 @@ class InteractionParser extends AbstractParser
             GapMatchInteraction::qtiTagName() => $this->parseGapMatchInteraction($element),
             HotspotInteraction::qtiTagName() => $this->parseHotspotInteraction($element),
             HottextInteraction::qtiTagName() => $this->parseHottextInteraction($element),
+            InlineChoiceInteraction::qtiTagName() => $this->parseInlineChoiceInteraction($element),
             MatchInteraction::qtiTagName() => $this->parseMatchInteraction($element),
             OrderInteraction::qtiTagName() => $this->parseOrderInteraction($element),
             SelectPointInteraction::qtiTagName() => $this->parseSelectPointInteraction($element),
@@ -169,6 +172,35 @@ class InteractionParser extends AbstractParser
         $maxChoices = (int) ($element->getAttribute('max-choices') ?: '0');
         $content = $this->parseContentChildren($element);
         return new HottextInteraction($maxChoices, $content, $responseIdentifier);
+    }
+
+    private function parseInlineChoiceInteraction(DOMElement $element): InlineChoiceInteraction
+    {
+        $this->validateTag($element, InlineChoiceInteraction::qtiTagName());
+        $responseIdentifier = $element->getAttribute('response-identifier') ?: 'RESPONSE';
+        $shuffle = strtolower($element->getAttribute('shuffle')) === 'true';
+        $required = strtolower($element->getAttribute('required')) === 'true';
+
+        $choices = [];
+        foreach ($this->getChildren($element) as $child) {
+            if ($child->nodeName === InlineChoice::qtiTagName()) {
+                $choices[] = $this->parseInlineChoice($child);
+            }
+        }
+
+        return new InlineChoiceInteraction($choices, $responseIdentifier, $shuffle, $required);
+    }
+
+    private function parseInlineChoice(DOMElement $element): InlineChoice
+    {
+        $this->validateTag($element, InlineChoice::qtiTagName());
+        $identifier = $element->getAttribute('identifier');
+        $fixed = strtolower($element->getAttribute('fixed')) === 'true';
+        $templateIdentifier = $element->getAttribute('template-identifier') ?: null;
+        $showHide = $element->getAttribute('show-hide') ?: 'show';
+        $content = $this->parseContentChildren($element);
+
+        return new InlineChoice($identifier, $content, $fixed, $templateIdentifier, $showHide);
     }
 
     private function parseMatchInteraction(DOMElement $element): MatchInteraction

--- a/src/Shared/Model/AbstractBaseSequenceElement.php
+++ b/src/Shared/Model/AbstractBaseSequenceElement.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 namespace Qti3\Shared\Model;
 
 /**
- * Base for any QTI element that carries the shared attribute set — the
+ * Base for any QTI element that carries the `BaseSequence` attribute set — the
  * interactions, their choices/gaps/prompts/labels, and (in principle) any other
  * body element the QTI base types sit under.
  *
- * It accepts a single {@see SharedAttributes} value object and unpacks it into
+ * It accepts a single {@see BaseSequenceAttributes} value object and unpacks it into
  * individual typed, readonly properties, so every element exposes e.g.
  * `$element->id`, `$element->class`, `$element->role` directly, plus the open
  * aria-* and data-* maps.
  *
  * The parser only fills the attributes the schema permits for a given element
- * (see {@see \Qti3\AssessmentItem\Service\Parser\AbstractParser::readSharedAttributes()});
+ * (see {@see \Qti3\AssessmentItem\Service\Parser\AbstractParser::readBaseSequenceAttributes()});
  * anything else is dropped, so an unsupported attribute is never carried on the
  * model nor re-emitted.
  */
-abstract class AbstractSharedAttributeElement extends QtiElement
+abstract class AbstractBaseSequenceElement extends QtiElement
 {
     public readonly ?string $id;
 
@@ -39,7 +39,7 @@ abstract class AbstractSharedAttributeElement extends QtiElement
     /** @var array<string,string> */
     public readonly array $dataAttributes;
 
-    public function __construct(SharedAttributes $attributes = new SharedAttributes())
+    public function __construct(BaseSequenceAttributes $attributes = new BaseSequenceAttributes())
     {
         $this->id = $attributes->id;
         $this->class = $attributes->class;
@@ -52,13 +52,13 @@ abstract class AbstractSharedAttributeElement extends QtiElement
     }
 
     /**
-     * The shared attributes in serialization form, to be merged into the
+     * The base-sequence attributes in serialization form, to be merged into the
      * concrete element's own attributes(). Only attributes that are actually
      * set are returned, so absent ones are never emitted.
      *
      * @return array<string,string>
      */
-    protected function sharedAttributes(): array
+    protected function baseSequenceAttributes(): array
     {
         $named = array_filter([
             'id' => $this->id,

--- a/src/Shared/Model/AbstractSharedAttributeElement.php
+++ b/src/Shared/Model/AbstractSharedAttributeElement.php
@@ -2,18 +2,35 @@
 
 declare(strict_types=1);
 
-namespace Qti3\AssessmentItem\Model\Interaction;
+namespace Qti3\Shared\Model;
 
-use Qti3\Shared\Model\QtiElement;
-use Qti3\Shared\Model\SharedAttributes;
-
-abstract class AbstractInteractionElement extends QtiElement
+/**
+ * Base for any QTI element that carries the shared attribute set — the
+ * interactions, their choices/gaps/prompts/labels, and (in principle) any other
+ * body element the QTI base types sit under.
+ *
+ * It accepts a single {@see SharedAttributes} value object and unpacks it into
+ * individual typed, readonly properties, so every element exposes e.g.
+ * `$element->id`, `$element->class`, `$element->role` directly, plus the open
+ * aria-* and data-* maps.
+ *
+ * The parser only fills the attributes the schema permits for a given element
+ * (see {@see \Qti3\AssessmentItem\Service\Parser\AbstractParser::readSharedAttributes()});
+ * anything else is dropped, so an unsupported attribute is never carried on the
+ * model nor re-emitted.
+ */
+abstract class AbstractSharedAttributeElement extends QtiElement
 {
     public readonly ?string $id;
+
     public readonly ?string $class;
+
     public readonly ?string $xmlLang;
+
     public readonly ?string $label;
+
     public readonly ?string $dir;
+
     public readonly ?string $role;
 
     /** @var array<string,string> */
@@ -35,6 +52,10 @@ abstract class AbstractInteractionElement extends QtiElement
     }
 
     /**
+     * The shared attributes in serialization form, to be merged into the
+     * concrete element's own attributes(). Only attributes that are actually
+     * set are returned, so absent ones are never emitted.
+     *
      * @return array<string,string>
      */
     protected function sharedAttributes(): array

--- a/src/Shared/Model/BaseSequenceAttributes.php
+++ b/src/Shared/Model/BaseSequenceAttributes.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Qti3\Shared\Model;
 
 /**
- * The attributes the QTI base types share across body, interaction and choice
- * elements: the HTML-ish global attributes (id, class, xml:lang, label, dir),
- * the WAI-ARIA role, and the two open attribute families (aria-* and the data-*
- * extension attributes) as name => value maps.
+ * The attribute set carried by the QTI base type `BaseSequenceDType` (see the
+ * bundled ASI schema `imsqti_asiv3p0_v1p0.xsd`): the HTML-ish global attributes
+ * (id, class, xml:lang, label, dir), the WAI-ARIA role, and the two open
+ * attribute families (aria-* and the data-* extension attributes) as
+ * name => value maps.
  *
- * These are not specific to any one element kind; they come from the shared
- * base types (ARIABase, BaseSequence, ...) that sit under most of the schema.
+ * `BaseSequence` extends `ARIABase` (role + aria-*) and adds the globals plus
+ * the data-* extension family, so it is the shared anchor most body,
+ * interaction and choice elements sit under.
  */
-final readonly class SharedAttributes
+final readonly class BaseSequenceAttributes
 {
     /**
      * @param array<string,string> $ariaAttributes aria-* attributes, verbatim

--- a/src/Shared/Model/SharedAttributes.php
+++ b/src/Shared/Model/SharedAttributes.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Shared\Model;
+
+/**
+ * The attributes the QTI base types share across body, interaction and choice
+ * elements: the HTML-ish global attributes (id, class, xml:lang, label, dir),
+ * the WAI-ARIA role, and the two open attribute families (aria-* and the data-*
+ * extension attributes) as name => value maps.
+ *
+ * These are not specific to any one element kind; they come from the shared
+ * base types (ARIABase, BaseSequence, ...) that sit under most of the schema.
+ */
+final readonly class SharedAttributes
+{
+    /**
+     * @param array<string,string> $ariaAttributes aria-* attributes, verbatim
+     * @param array<string,string> $dataAttributes data-* extension attributes, verbatim
+     */
+    public function __construct(
+        public ?string $id = null,
+        public ?string $class = null,
+        public ?string $xmlLang = null,
+        public ?string $label = null,
+        public ?string $dir = null,
+        public ?string $role = null,
+        public array $ariaAttributes = [],
+        public array $dataAttributes = [],
+    ) {}
+}

--- a/tests/Integration/ItemParserSerializationTest.php
+++ b/tests/Integration/ItemParserSerializationTest.php
@@ -11,6 +11,7 @@ use Qti3\AssessmentItem\Model\Feedback\FeedbackBlock;
 use Qti3\AssessmentItem\Model\Feedback\Visibility;
 use Qti3\AssessmentItem\Model\Interaction\ChoiceInteraction\ChoiceInteraction;
 use Qti3\AssessmentItem\Model\Interaction\ExtendedTextInteraction\ExtendedTextInteraction;
+use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoiceInteraction;
 use Qti3\AssessmentItem\Model\Interaction\TextEntryInteraction\TextEntryInteraction;
 use Qti3\AssessmentItem\Model\ResponseProcessing\ResponseCondition;
 use Qti3\AssessmentItem\Model\RubricBlock\RubricBlock;
@@ -441,6 +442,69 @@ XML;
         $this->assertNotNull($second->responseProcessing);
         $this->assertCount(1, $second->responseProcessing->elements);
         $this->assertInstanceOf(ResponseCondition::class, $second->responseProcessing->elements[0]);
+    }
+
+    /**
+     * Verifies that an inline choice interaction embedded inside a paragraph
+     * survives a parse -> serialize -> re-parse cycle with its choices and
+     * attributes preserved. Inline interactions are nested within surrounding
+     * HTML content rather than sitting at item-body top level.
+     */
+    public function testSerializeItemWithInlineChoiceInteraction(): void
+    {
+        $xml = <<<XML
+<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+                    identifier="inline-choice-001"
+                    title="Inline Choice Item"
+                    adaptive="false"
+                    time-dependent="false">
+    <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="identifier">
+        <qti-correct-response>
+            <qti-value>G</qti-value>
+        </qti-correct-response>
+    </qti-response-declaration>
+    <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float" />
+    <qti-item-body>
+        <p>Water vapour is in the
+            <qti-inline-choice-interaction response-identifier="RESPONSE" shuffle="true" required="true">
+                <qti-inline-choice identifier="G">gaseous</qti-inline-choice>
+                <qti-inline-choice identifier="L" fixed="true">liquid</qti-inline-choice>
+                <qti-inline-choice identifier="S">solid</qti-inline-choice>
+            </qti-inline-choice-interaction>
+            state.</p>
+    </qti-item-body>
+    <qti-response-processing template="https://www.imsglobal.org/question/qti_v3p0/rptemplates/match_correct" />
+</qti-assessment-item>
+XML;
+
+        $first = $this->parseItem($xml);
+        $serialized = $this->serializeItem($first);
+        $second = $this->parseItem($serialized);
+
+        $this->assertSame('inline-choice-001', (string) $second->identifier);
+
+        // The interaction is nested inside the surrounding paragraph.
+        $body = $second->itemBody->content->all();
+        $paragraph = $body[0];
+        $this->assertInstanceOf(HTMLTag::class, $paragraph);
+        $this->assertSame('p', $paragraph->tagName());
+
+        $interactions = array_values(array_filter(
+            $paragraph->children(),
+            static fn($node): bool => $node instanceof InlineChoiceInteraction,
+        ));
+        $this->assertCount(1, $interactions);
+
+        $interaction = $interactions[0];
+        $this->assertSame('RESPONSE', $interaction->responseIdentifier);
+        $this->assertTrue($interaction->shuffle);
+        $this->assertTrue($interaction->required);
+        $this->assertCount(3, $interaction->choices);
+        $this->assertSame('G', $interaction->choices[0]->identifier);
+        $this->assertSame('gaseous', $interaction->choices[0]->content->all()[0]->content);
+        $this->assertSame('L', $interaction->choices[1]->identifier);
+        $this->assertTrue($interaction->choices[1]->fixed);
+        $this->assertSame('S', $interaction->choices[2]->identifier);
     }
 
     /**

--- a/tests/Integration/ItemParserSerializationTest.php
+++ b/tests/Integration/ItemParserSerializationTest.php
@@ -466,7 +466,8 @@ XML;
     <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float" />
     <qti-item-body>
         <p>Water vapour is in the
-            <qti-inline-choice-interaction response-identifier="RESPONSE" shuffle="true" required="true">
+            <qti-inline-choice-interaction response-identifier="RESPONSE" shuffle="true" required="true" min-choices="1"
+                class="dropdown" data-prompt="choose" not-allowed="dropped">
                 <qti-inline-choice identifier="G">gaseous</qti-inline-choice>
                 <qti-inline-choice identifier="L" fixed="true">liquid</qti-inline-choice>
                 <qti-inline-choice identifier="S">solid</qti-inline-choice>
@@ -480,6 +481,13 @@ XML;
         $first = $this->parseItem($xml);
         $serialized = $this->serializeItem($first);
         $second = $this->parseItem($serialized);
+
+        // Spec-permitted shared and data-* attributes survive serialization; the
+        // unknown attribute is dropped and never re-emitted.
+        $this->assertStringContainsString('class="dropdown"', $serialized);
+        $this->assertStringContainsString('data-prompt="choose"', $serialized);
+        $this->assertStringContainsString('min-choices="1"', $serialized);
+        $this->assertStringNotContainsString('not-allowed', $serialized);
 
         $this->assertSame('inline-choice-001', (string) $second->identifier);
 
@@ -499,6 +507,9 @@ XML;
         $this->assertSame('RESPONSE', $interaction->responseIdentifier);
         $this->assertTrue($interaction->shuffle);
         $this->assertTrue($interaction->required);
+        $this->assertSame(1, $interaction->minChoices);
+        $this->assertSame('dropdown', $interaction->class);
+        $this->assertSame(['data-prompt' => 'choose'], $interaction->dataAttributes);
         $this->assertCount(3, $interaction->choices);
         $this->assertSame('G', $interaction->choices[0]->identifier);
         $this->assertSame('gaseous', $interaction->choices[0]->content->all()[0]->content);

--- a/tests/Unit/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/ExtendedTextInteraction/ExtendedTextInteractionTest.php
@@ -19,7 +19,18 @@ class ExtendedTextInteractionTest extends TestCase
         $interaction = new ExtendedTextInteraction();
 
         $this->assertEquals(
-            ['response-identifier' => 'RESPONSE'],
+            [
+                'response-identifier' => 'RESPONSE',
+                'base' => null,
+                'string-identifier' => null,
+                'expected-length' => null,
+                'pattern-mask' => null,
+                'placeholder-text' => null,
+                'max-strings' => null,
+                'min-strings' => null,
+                'expected-lines' => null,
+                'format' => null,
+            ],
             $interaction->attributes(),
         );
     }
@@ -30,7 +41,18 @@ class ExtendedTextInteractionTest extends TestCase
         $interaction = new ExtendedTextInteraction(responseIdentifier: 'CUSTOM_RESPONSE');
 
         $this->assertEquals(
-            ['response-identifier' => 'CUSTOM_RESPONSE'],
+            [
+                'response-identifier' => 'CUSTOM_RESPONSE',
+                'base' => null,
+                'string-identifier' => null,
+                'expected-length' => null,
+                'pattern-mask' => null,
+                'placeholder-text' => null,
+                'max-strings' => null,
+                'min-strings' => null,
+                'expected-lines' => null,
+                'format' => null,
+            ],
             $interaction->attributes(),
         );
     }

--- a/tests/Unit/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/GapMatchInteraction/GapMatchInteractionTest.php
@@ -46,7 +46,6 @@ class GapMatchInteractionTest extends TestCase
             'shuffle' => 'false',
             'max-associations' => 0,
             'min-associations' => null,
-            'class' => null,
         ], $this->gapMatchInteraction->attributes());
 
         $this->assertInstanceOf(HTMLTag::class, $this->gapMatchInteraction->children()[3]);

--- a/tests/Unit/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoiceTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotChoiceTest.php
@@ -28,6 +28,9 @@ class HotspotChoiceTest extends TestCase
             'shape' => 'circle',
             'coords' => '418,29,40',
             'identifier' => 'I',
+            'template-identifier' => null,
+            'show-hide' => 'show',
+            'hotspot-label' => null,
         ];
 
         $this->assertSame($expectedAttributes, $this->hotspotChoice->attributes());

--- a/tests/Unit/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/HotspotInteraction/HotspotInteractionTest.php
@@ -31,6 +31,7 @@ class HotspotInteractionTest extends TestCase
     {
         $expectedAttributes = [
             'max-choices' => '1',
+            'min-choices' => null,
             'response-identifier' => 'RESPONSE',
         ];
 

--- a/tests/Unit/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/HottextInteraction/HottextInteractionTest.php
@@ -29,6 +29,7 @@ class HottextInteractionTest extends TestCase
     {
         $expectedAttributes = [
             'max-choices' => '1',
+            'min-choices' => null,
             'response-identifier' => 'RESPONSE',
         ];
 

--- a/tests/Unit/AssessmentItem/Model/Interaction/HottextInteraction/HottextTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/HottextInteraction/HottextTest.php
@@ -31,6 +31,8 @@ class HottextTest extends TestCase
     {
         $expectedAttributes = [
             'identifier' => 'A',
+            'template-identifier' => null,
+            'show-hide' => 'show',
         ];
 
         $this->assertSame($expectedAttributes, $this->hottext->attributes());

--- a/tests/Unit/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/MatchInteraction/MatchInteractionTest.php
@@ -43,7 +43,7 @@ class MatchInteractionTest extends TestCase
             'response-identifier' => 'RESPONSE',
             'shuffle' => 'true',
             'max-associations' => '5',
-            'class' => null,
+            'min-associations' => null,
         ];
 
         $this->assertSame($expectedAttributes, $this->matchInteraction->attributes());

--- a/tests/Unit/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoiceTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoiceTest.php
@@ -36,7 +36,7 @@ class SimpleAssociableChoiceTest extends TestCase
             'match-min' => null,
             'fixed' => null,
             'template-identifier' => null,
-            'show-hide' => null,
+            'show-hide' => 'show',
             'match-group' => null,
         ];
 

--- a/tests/Unit/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoiceTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/MatchInteraction/SimpleAssociableChoiceTest.php
@@ -33,6 +33,11 @@ class SimpleAssociableChoiceTest extends TestCase
         $expectedAttributes = [
             'identifier' => 'CHOICE_1',
             'match-max' => '3',
+            'match-min' => null,
+            'fixed' => null,
+            'template-identifier' => null,
+            'show-hide' => null,
+            'match-group' => null,
         ];
 
         $this->assertSame($expectedAttributes, $this->simpleAssociableChoice->attributes());

--- a/tests/Unit/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/OrderInteraction/OrderInteractionTest.php
@@ -46,6 +46,8 @@ class OrderInteractionTest extends TestCase
             'response-identifier' => 'RESPONSE',
             'orientation' => 'horizontal',
             'shuffle' => 'true',
+            'min-choices' => null,
+            'max-choices' => null,
         ];
 
         $this->assertSame($expectedAttributes, $this->orderInteraction->attributes());

--- a/tests/Unit/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/SelectPointInteraction/SelectPointInteractionTest.php
@@ -39,6 +39,7 @@ class SelectPointInteractionTest extends TestCase
         $this->assertEquals(
             [
                 'max-choices' => '1',
+                'min-choices' => null,
                 'response-identifier' => 'RESPONSE',
             ],
             $this->interaction->attributes(),

--- a/tests/Unit/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteractionTest.php
+++ b/tests/Unit/AssessmentItem/Model/Interaction/TextEntryInteraction/TextEntryInteractionTest.php
@@ -28,6 +28,17 @@ class TextEntryInteractionTest extends TestCase
     public function textEntryInteractionCanBeCreatedWithResponseIdentifier(): void
     {
         $textEntryInteractionWithResponse = new TextEntryInteraction('RESPONSE2');
-        $this->assertEquals(['response-identifier' => 'RESPONSE2'], $textEntryInteractionWithResponse->attributes());
+        $this->assertEquals(
+            [
+                'response-identifier' => 'RESPONSE2',
+                'base' => null,
+                'string-identifier' => null,
+                'expected-length' => null,
+                'pattern-mask' => null,
+                'placeholder-text' => null,
+                'format' => null,
+            ],
+            $textEntryInteractionWithResponse->attributes(),
+        );
     }
 }

--- a/tests/Unit/AssessmentItem/Service/Parser/InteractionParserTest.php
+++ b/tests/Unit/AssessmentItem/Service/Parser/InteractionParserTest.php
@@ -333,6 +333,23 @@ class InteractionParserTest extends TestCase
     }
 
     #[Test]
+    public function dropsAriaAttributesNotEnumeratedByTheSchema(): void
+    {
+        // aria-label is enumerated by ARIABaseDType; aria-foo is not and must be dropped.
+        $element = $this->loadElement('
+            <qti-inline-choice-interaction response-identifier="RESPONSE"
+                aria-label="keep me" aria-foo="drop me">
+                <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+            </qti-inline-choice-interaction>
+        ');
+
+        $result = $this->parser->parse($element);
+
+        $this->assertSame(['aria-label' => 'keep me'], $result->ariaAttributes);
+        $this->assertArrayNotHasKey('aria-foo', $result->ariaAttributes);
+    }
+
+    #[Test]
     public function dropsAriaAndRoleOnElementsThatDoNotAllowThem(): void
     {
         // qti-simple-match-set only permits id (+ data-*): it does not extend the ARIA base.

--- a/tests/Unit/AssessmentItem/Service/Parser/InteractionParserTest.php
+++ b/tests/Unit/AssessmentItem/Service/Parser/InteractionParserTest.php
@@ -18,6 +18,7 @@ use Qti3\AssessmentItem\Model\Interaction\GapMatchInteraction\GapText;
 use Qti3\AssessmentItem\Model\Interaction\HotspotInteraction\HotspotInteraction;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\Hottext;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\HottextInteraction;
+use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoiceInteraction;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\MatchInteraction;
 use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\OrderInteraction;
 use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\Orientation;
@@ -208,6 +209,71 @@ class InteractionParserTest extends TestCase
         $this->assertSame('RESPONSE_HT', $result->responseIdentifier);
         $this->assertSame(2, $result->maxChoices);
         $this->assertGreaterThan(0, count($result->content));
+    }
+
+    #[Test]
+    public function parseInlineChoiceInteraction(): void
+    {
+        $element = $this->loadElement('
+            <qti-inline-choice-interaction response-identifier="RESPONSE_IC" shuffle="true" required="true">
+                <qti-inline-choice identifier="G">gaseous</qti-inline-choice>
+                <qti-inline-choice identifier="L">liquid</qti-inline-choice>
+                <qti-inline-choice identifier="S">solid</qti-inline-choice>
+            </qti-inline-choice-interaction>
+        ');
+
+        $result = $this->parser->parse($element);
+
+        $this->assertInstanceOf(InlineChoiceInteraction::class, $result);
+        $this->assertSame('RESPONSE_IC', $result->responseIdentifier);
+        $this->assertTrue($result->shuffle);
+        $this->assertTrue($result->required);
+        $this->assertCount(3, $result->choices);
+        $this->assertSame('G', $result->choices[0]->identifier);
+        $this->assertInstanceOf(TextNode::class, $result->choices[0]->content->all()[0]);
+        $this->assertSame('gaseous', $result->choices[0]->content->all()[0]->content);
+        $this->assertSame('L', $result->choices[1]->identifier);
+        $this->assertSame('S', $result->choices[2]->identifier);
+    }
+
+    #[Test]
+    public function parseInlineChoiceInteractionDefaults(): void
+    {
+        $element = $this->loadElement('
+            <qti-inline-choice-interaction>
+                <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+            </qti-inline-choice-interaction>
+        ');
+
+        $result = $this->parser->parse($element);
+
+        $this->assertInstanceOf(InlineChoiceInteraction::class, $result);
+        $this->assertSame('RESPONSE', $result->responseIdentifier);
+        $this->assertFalse($result->shuffle);
+        $this->assertFalse($result->required);
+        $this->assertCount(1, $result->choices);
+        $choice = $result->choices[0];
+        $this->assertSame('A', $choice->identifier);
+        $this->assertFalse($choice->fixed);
+        $this->assertNull($choice->templateIdentifier);
+        $this->assertSame('show', $choice->showHide);
+    }
+
+    #[Test]
+    public function parseInlineChoiceKeepsChoiceAttributes(): void
+    {
+        $element = $this->loadElement('
+            <qti-inline-choice-interaction response-identifier="RESPONSE">
+                <qti-inline-choice identifier="A" fixed="true" template-identifier="SHOW_A" show-hide="hide">Alpha</qti-inline-choice>
+            </qti-inline-choice-interaction>
+        ');
+
+        $result = $this->parser->parse($element);
+
+        $choice = $result->choices[0];
+        $this->assertTrue($choice->fixed);
+        $this->assertSame('SHOW_A', $choice->templateIdentifier);
+        $this->assertSame('hide', $choice->showHide);
     }
 
     #[Test]

--- a/tests/Unit/AssessmentItem/Service/Parser/InteractionParserTest.php
+++ b/tests/Unit/AssessmentItem/Service/Parser/InteractionParserTest.php
@@ -19,6 +19,7 @@ use Qti3\AssessmentItem\Model\Interaction\HotspotInteraction\HotspotInteraction;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\Hottext;
 use Qti3\AssessmentItem\Model\Interaction\HottextInteraction\HottextInteraction;
 use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\InlineChoiceInteraction;
+use Qti3\AssessmentItem\Model\Interaction\InlineChoiceInteraction\Label;
 use Qti3\AssessmentItem\Model\Interaction\MatchInteraction\MatchInteraction;
 use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\OrderInteraction;
 use Qti3\AssessmentItem\Model\Interaction\OrderInteraction\Orientation;
@@ -215,7 +216,7 @@ class InteractionParserTest extends TestCase
     public function parseInlineChoiceInteraction(): void
     {
         $element = $this->loadElement('
-            <qti-inline-choice-interaction response-identifier="RESPONSE_IC" shuffle="true" required="true">
+            <qti-inline-choice-interaction response-identifier="RESPONSE_IC" shuffle="true" required="true" min-choices="1">
                 <qti-inline-choice identifier="G">gaseous</qti-inline-choice>
                 <qti-inline-choice identifier="L">liquid</qti-inline-choice>
                 <qti-inline-choice identifier="S">solid</qti-inline-choice>
@@ -228,6 +229,7 @@ class InteractionParserTest extends TestCase
         $this->assertSame('RESPONSE_IC', $result->responseIdentifier);
         $this->assertTrue($result->shuffle);
         $this->assertTrue($result->required);
+        $this->assertSame(1, $result->minChoices);
         $this->assertCount(3, $result->choices);
         $this->assertSame('G', $result->choices[0]->identifier);
         $this->assertInstanceOf(TextNode::class, $result->choices[0]->content->all()[0]);
@@ -260,6 +262,26 @@ class InteractionParserTest extends TestCase
     }
 
     #[Test]
+    public function parseInlineChoiceInteractionWithLabel(): void
+    {
+        $element = $this->loadElement('
+            <qti-inline-choice-interaction response-identifier="RESPONSE">
+                <qti-label class="lbl">Choose one</qti-label>
+                <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+            </qti-inline-choice-interaction>
+        ');
+
+        $result = $this->parser->parse($element);
+
+        $this->assertInstanceOf(Label::class, $result->labelElement);
+        $this->assertSame('lbl', $result->labelElement->class);
+        $this->assertSame('Choose one', $result->labelElement->content->all()[0]->content);
+        // The label precedes the choices, matching the schema's child sequence.
+        $this->assertSame($result->labelElement, $result->children()[0]);
+        $this->assertCount(1, $result->choices);
+    }
+
+    #[Test]
     public function parseInlineChoiceKeepsChoiceAttributes(): void
     {
         $element = $this->loadElement('
@@ -274,6 +296,63 @@ class InteractionParserTest extends TestCase
         $this->assertTrue($choice->fixed);
         $this->assertSame('SHOW_A', $choice->templateIdentifier);
         $this->assertSame('hide', $choice->showHide);
+    }
+
+    #[Test]
+    public function keepsSpecAllowedAttributesAndDropsDisallowedOnes(): void
+    {
+        $element = $this->loadElement('
+            <qti-inline-choice-interaction response-identifier="RESPONSE" min-choices="1"
+                id="ic1" class="fancy" xml:lang="en" dir="ltr"
+                data-custom="x" aria-label="pick one" role="listbox"
+                not-a-real-attribute="drop-me">
+                <qti-inline-choice identifier="A" data-note="keep" bogus="drop">Alpha</qti-inline-choice>
+            </qti-inline-choice-interaction>
+        ');
+
+        $result = $this->parser->parse($element);
+
+        // Element-specific attributes are read into their own typed properties.
+        $this->assertSame(1, $result->minChoices);
+
+        // Shared globals become typed properties; role is typed; aria-*/data-* are maps.
+        $this->assertSame('ic1', $result->id);
+        $this->assertSame('fancy', $result->class);
+        $this->assertSame('en', $result->xmlLang);
+        $this->assertSame('ltr', $result->dir);
+        $this->assertSame('listbox', $result->role);
+        $this->assertSame(['aria-label' => 'pick one'], $result->ariaAttributes);
+        $this->assertSame(['data-custom' => 'x'], $result->dataAttributes);
+
+        // The unknown attribute is not permitted for this element and is dropped.
+        $this->assertArrayNotHasKey('not-a-real-attribute', $result->dataAttributes);
+        $this->assertArrayNotHasKey('not-a-real-attribute', $result->ariaAttributes);
+
+        // The same allowlisting applies to the child element.
+        $this->assertSame(['data-note' => 'keep'], $result->choices[0]->dataAttributes);
+    }
+
+    #[Test]
+    public function dropsAriaAndRoleOnElementsThatDoNotAllowThem(): void
+    {
+        // qti-simple-match-set only permits id (+ data-*): it does not extend the ARIA base.
+        $element = $this->loadElement('
+            <qti-match-interaction response-identifier="RESPONSE">
+                <qti-simple-match-set id="set1" role="list" aria-label="nope" data-x="y" foo="bar">
+                    <qti-simple-associable-choice identifier="S1" match-max="1">Source</qti-simple-associable-choice>
+                </qti-simple-match-set>
+                <qti-simple-match-set/>
+            </qti-match-interaction>
+        ');
+
+        $set = $this->parser->parse($element)->simpleMatchSet1;
+
+        $this->assertSame('set1', $set->id);
+        $this->assertSame(['data-x' => 'y'], $set->dataAttributes);
+        // role/aria-* are not permitted here, nor is the unknown attribute.
+        $this->assertNull($set->role);
+        $this->assertSame([], $set->ariaAttributes);
+        $this->assertArrayNotHasKey('foo', $set->dataAttributes);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Adds support for **`qti-inline-choice-interaction`** (with its `qti-inline-choice` and `qti-label` children) and, in the process, brings **every** interaction and choice element up to spec for attribute coverage via a shared, typed attribute model.

## What changed

**New interaction — `qti-inline-choice-interaction`**
- Typed models `InlineChoiceInteraction`, `InlineChoice`, and `Label` (`qti-label`) with parsing and serialization.
- Works wherever the interaction appears, including nested inside content (it's an inline interaction); items containing it are classified as `question` by the determinator with no extra wiring.

**Shared attribute model (applies to all interaction/choice elements)**
- New `BaseSequenceAttributes` value object (`Qti3\Shared\Model`) holding the attribute set of the QTI base type `BaseSequenceDType` (`ARIABase` role + `aria-*`, the HTML global attributes `id`, `class`, `xml:lang`, `label`, `dir`, and the open-ended `data-*` extension family), with `aria-*` / `data-*` carried as maps.
- New `AbstractBaseSequenceElement` base (`Qti3\Shared\Model`, alongside `QtiElement`/`BaseSequenceAttributes`) unpacks that value object into individual **typed, readonly** properties, so every element exposes `->id`, `->class`, `->role`, `->dataAttributes`, etc. directly. Concrete elements take a single `BaseSequenceAttributes $attributes` constructor argument and forward it. It bases both the interactions and their constituent parts (choices, gaps, prompts, labels, match-sets), and is deliberately not interaction-specific — hence its home in `Qti3\Shared\Model` rather than the interaction namespace.
- New `AbstractParser::readBaseSequenceAttributes()` reads only the attributes the schema permits for a given element; **unknown / disallowed attributes are dropped**, never passed through to the model or re-emitted. `aria-*` attributes are validated against the `ARIABaseDType` enumeration from the bundled XSD, so unknown ones (e.g. `aria-foo`) are dropped like any other non-permitted attribute.

**Attribute completeness for existing interactions**
- Every interaction/choice now models its full set of spec attributes (e.g. `min-choices`, `orientation` on choice; `base`/`expected-length`/`pattern-mask`/`placeholder-text`/`format` on text entry; `max-strings`/`min-strings`/`expected-lines` on extended text; `match-max`/`match-min`/`fixed`/`template-identifier`/`show-hide`/`match-group` on associable choices; `hotspot-label`; `min-choices` on hotspot/hottext/select-point/order; etc.).
- `qti-label` — the one child element previously **silently dropped** — is now typed as `Label`.
- `show-hide` now defaults to `'show'` (non-nullable `string`) uniformly across **all** choice types; `SimpleAssociableChoice` previously defaulted to `null`, so it now round-trips consistently with its siblings.

**Docs / misc**
- README "Supported interactions" list updated to include `qti-inline-choice-interaction`.
- Corrected the stale `AssessmentItemValidator` docblock that cited inline-choice as unsupported.

## Design decisions

- **`BaseSequenceAttributes` as one value object unpacked by the base constructor** gives readonly immutability and direct `->id` access while keeping each element's constructor to a single extra parameter (no per-property forwarding boilerplate). Named after the QTI base type `BaseSequenceDType` it represents, rather than a generic "shared" label.
- **Strict allowlist**: only spec-permitted attributes are retained per element; anything else is dropped (preserves the prior "don't invent data" behaviour). ARIA attributes are held to the enumerated `ARIABaseDType` set, not a blanket `aria-*` prefix match.
- **`MatchInteraction.class`** was a bespoke property duplicating the shared HTML `class`; it is now handled by the base like every other element.

## Known follow-ups (out of scope)

- **Dropped attributes are silent.** `readBaseSequenceAttributes()` drops disallowed attributes without emitting a parse warning, and the `ItemBody` subtree collects no warnings today (for any node, not just interactions). Surfacing body-subtree data-loss as warnings — as the item/test parsers already do — is a broader, pre-existing gap best handled as a dedicated follow-up rather than in this PR.

## Intentional deviations from the raw XSD

- Local `lang` and `xml:base` (permitted by the base types) are **not** modelled — only `xml:lang` is kept. Items using those lose them on round-trip. Deliberate.
- Allowed child elements other than `qti-label` (`qti-gap-img`, `qti-feedback-block`, `qti-template-block`, `qti-printed-variable`, `qti-template-inline`) are preserved verbatim as generic content (`HTMLTag`) rather than typed models. Typing them — especially the templating elements — is deferred as separate work.

## Attribute audit (own attributes per XSD → coverage)

| Element | Own attrs (XSD) | Coverage |
|---|---|---|
| ChoiceInteraction | shuffle, max/min-choices, orientation, data-*×2 | typed + data-* map |
| TextEntryInteraction | response-identifier, base, string-identifier, expected-length, pattern-mask, placeholder-text, format, data-* | typed + map |
| ExtendedTextInteraction | base, string-identifier, expected-length, pattern-mask, placeholder-text, max/min-strings, expected-lines, format, data-* | typed + map |
| GapMatchInteraction | shuffle, min/max-associations, data-*×3 | typed + map |
| HotspotInteraction | min/max-choices, data-*×2 | typed + map |
| HottextInteraction | max/min-choices, data-*×2 | typed + map |
| InlineChoiceInteraction | shuffle, required, min-choices, data-*×2 | typed + map |
| MatchInteraction | shuffle, max/min-associations, data-*×3 | typed + map |
| OrderInteraction | shuffle, min/max-choices, orientation, data-*×3 | typed + map |
| SelectPointInteraction | min/max-choices | typed |
| SimpleChoice | identifier, fixed, template-identifier, show-hide | typed |
| SimpleAssociableChoice | identifier, fixed, template-identifier, show-hide, match-group, match-max/min | typed |
| SimpleMatchSet | id only (no ARIA base) | shared restricted to `id`, aria off |
| HotspotChoice | identifier, template-identifier, show-hide, shape, coords, hotspot-label | typed (coords via shape) |
| Hottext | identifier, template-identifier, show-hide | typed |
| Gap | identifier, template-identifier, show-hide, match-group, required | typed |
| GapText | identifier, template-identifier, show-hide, match-group, match-max/min | typed |
| InlineChoice | identifier, fixed, template-identifier, show-hide | typed |
| Prompt | (shared only) | shared |
| Label (qti-label) | (shared only) | shared |

The shared globals (`id`, `class`, `xml:lang`, `label`, `dir`, `role`) plus `aria-*` / `data-*` are provided to every element by `BaseSequenceAttributes`; `response-identifier` (required on interactions) is typed per interaction.

## Testing

- Full PHPUnit suite green; PHPStan level 0 clean.
- `InteractionParserTest`: inline-choice parsing (attributes + defaults + per-choice attributes), `qti-label` parsing, and allowlist behaviour — spec-allowed attributes kept as typed props / maps, unknown attributes dropped, `aria-*` outside the `ARIABaseDType` enumeration dropped (`aria-label` kept, `aria-foo` dropped), aria/role dropped on `qti-simple-match-set`.
- `ItemParserSerializationTest`: inline-choice interaction embedded in a paragraph survives parse → serialize → re-parse, with shared + `data-*` attributes preserved and a disallowed attribute dropped.
- Model unit tests updated for the expanded `attributes()` output, including the `show-hide` default alignment on `SimpleAssociableChoice`.
