### PR TITLE
Validate item resource references on add/update

### DIFF
--- a/docs/package-editor.md
+++ b/docs/package-editor.md
@@ -171,6 +171,21 @@ $parsed = $qtiClient->getAssessmentItemParser()->parseFromString($itemXml);
 $editor->updateItem($package, $parsed->item);
 ```
 
+## Resource references are validated on add and update
+
+When an item is added or updated, every resource reference in its content
+(image `src`, `<source>` `srcset`, …) is checked against the package **before
+anything is written**. A reference is valid when it points to a file already in
+the package (such as one added with `addResource`), a `data:` URI, an `http(s)`
+URL, or a trusted library asset. A reference to a resource that is not in the
+package — or a path that escapes it (absolute, or containing `..`) — throws
+`InvalidResourceReferenceException`; the edit is rejected and the package is left
+untouched. The exception lists every offending reference (`validationErrors()`),
+so a caller such as the editor backend can report exactly which media are
+missing. For accepted references the item's manifest dependencies are
+reconciled automatically: newly referenced resources are linked and references
+the item dropped are unlinked.
+
 ## Removing an item
 
 ```php
@@ -230,6 +245,7 @@ $qtiClient->getFilesystemPackageFactory()->getWriter('/tmp/my-package')->write($
 | Unknown `$testId`, or updating/removing a non-existent item | `Qti3\Shared\Exception\ResourceNotFoundException` |
 | Adding an item whose identifier already exists in the package | `Qti3\AssessmentTest\Exception\InvalidAssessmentTestException` |
 | Reorder list that does not match the items in the test | `Qti3\AssessmentTest\Exception\InvalidItemOrderException` |
+| Adding/updating an item whose content references a resource not in the package (or a path outside it) | `Qti3\Package\Exception\InvalidResourceReferenceException` |
 
 A construct the model cannot hold (outcome processing, test feedback, rubric
 blocks, nested sections, a template declaration, an unconsumed attribute, ...)

--- a/src/Package/Exception/InvalidResourceReferenceException.php
+++ b/src/Package/Exception/InvalidResourceReferenceException.php
@@ -34,7 +34,7 @@ final class InvalidResourceReferenceException extends DomainError implements Has
 
     protected function errorMessage(): string
     {
-        return 'Item references one or more resources that are not present in the package';
+        return 'Item references one or more resources that cannot be resolved against the package';
     }
 
     public function validationErrors(): StringCollection

--- a/src/Package/Exception/InvalidResourceReferenceException.php
+++ b/src/Package/Exception/InvalidResourceReferenceException.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Package\Exception;
+
+use Qti3\Shared\Collection\StringCollection;
+use Qti3\Shared\Exception\DomainError;
+use Qti3\Shared\Exception\ErrorType;
+use Qti3\Shared\Exception\HasValidationErrors;
+
+/**
+ * Thrown when item content references a resource that cannot be resolved
+ * against the package: a relative path not present in the package, or a path
+ * that escapes it. Each offending reference is listed in the validation errors.
+ */
+final class InvalidResourceReferenceException extends DomainError implements HasValidationErrors
+{
+    public function __construct(
+        private readonly StringCollection $validationErrors,
+    ) {
+        parent::__construct($this->errorMessage());
+    }
+
+    public function errorCode(): string
+    {
+        return 'invalid_resource_reference';
+    }
+
+    public function errorType(): ErrorType
+    {
+        return ErrorType::VALIDATION;
+    }
+
+    protected function errorMessage(): string
+    {
+        return 'Item references one or more resources that are not present in the package';
+    }
+
+    public function validationErrors(): StringCollection
+    {
+        return $this->validationErrors;
+    }
+}

--- a/src/Package/Service/PackageEditor.php
+++ b/src/Package/Service/PackageEditor.php
@@ -17,6 +17,7 @@ use Qti3\AssessmentTest\Model\ItemRef\AssessmentItemRef;
 use Qti3\AssessmentTest\Service\TestBuilder;
 use Qti3\AssessmentTest\Service\TestParseResult;
 use Qti3\Package\Exception\InvalidQtiPackageException;
+use Qti3\Package\Exception\InvalidResourceReferenceException;
 use Qti3\Package\Model\FileContent\IFileContent;
 use Qti3\Package\Model\Manifest\ManifestResourceDependency;
 use Qti3\Package\Model\Manifest\ManifestResourceDependencyCollection;
@@ -110,6 +111,10 @@ final readonly class PackageEditor
         $this->assertIdentifierAvailable($package, $identifier);
         $item = $item->withIdentifier(AssessmentItemId::fromString($identifier));
 
+        // Every resource the item references must resolve against the package
+        // before anything is mutated; an unresolvable reference fails the edit.
+        $this->assertResourceReferencesResolve($package, $item);
+
         // Media-resolution warnings join the test-parse warnings: both surface
         // data loss the caller must see (a refused reference leaves a dangling
         // src in the regenerated item).
@@ -137,6 +142,10 @@ final readonly class PackageEditor
     {
         $identifier = (string) $item->identifier();
         $itemResource = $package->getResource($identifier, ResourceType::ASSESSMENT_ITEM);
+
+        // Every resource the item references must resolve against the package
+        // before anything is mutated; an unresolvable reference fails the edit.
+        $this->assertResourceReferencesResolve($package, $item);
 
         // Which media the item referenced *before* this edit, derived from the
         // current content by the same scan that produces the new dependencies.
@@ -223,6 +232,21 @@ final readonly class PackageEditor
         );
 
         $this->getXmlFileFromResource($testResource)->replaceContent((string) $rebuilt->getMainFile());
+    }
+
+    /**
+     * Fail the edit when the item references a resource that cannot be resolved
+     * against the package (a relative path not present in it, or a path that
+     * escapes it). Called before any mutation, so a rejected edit leaves the
+     * package untouched. In-package files, `data:` URIs, `http(s)` URLs and
+     * trusted library assets are all valid references.
+     */
+    private function assertResourceReferencesResolve(QtiPackage $package, AssessmentItem $item): void
+    {
+        $invalidReferences = $this->webcontentProcessor->findInvalidReferences($item, $package);
+        if ($invalidReferences !== []) {
+            throw new InvalidResourceReferenceException(new StringCollection($invalidReferences));
+        }
     }
 
     /**

--- a/src/Package/Service/WebcontentProcessor.php
+++ b/src/Package/Service/WebcontentProcessor.php
@@ -115,6 +115,24 @@ final readonly class WebcontentProcessor
      */
     public function findInvalidReferences(IXmlElement $element, QtiPackage $package): array
     {
+        // The element itself may be a resource provider (many nodes are), so it
+        // is checked too, not just its descendants.
+        $invalid = [];
+        if ($element instanceof IQtiResourceProvider) {
+            $message = $this->invalidReferenceMessage($element, $package);
+            if ($message !== null) {
+                $invalid[] = $message;
+            }
+        }
+
+        return [...$invalid, ...$this->invalidReferencesInDescendants($element, $package)];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function invalidReferencesInDescendants(IXmlElement $element, QtiPackage $package): array
+    {
         $invalid = [];
         foreach ($element->children() as $child) {
             if ($child instanceof IQtiResourceProvider) {
@@ -124,7 +142,7 @@ final readonly class WebcontentProcessor
                 }
             }
             if ($child instanceof IXmlElement) {
-                $invalid = [...$invalid, ...$this->findInvalidReferences($child, $package)];
+                $invalid = [...$invalid, ...$this->invalidReferencesInDescendants($child, $package)];
             }
         }
 

--- a/src/Package/Service/WebcontentProcessor.php
+++ b/src/Package/Service/WebcontentProcessor.php
@@ -104,6 +104,54 @@ final readonly class WebcontentProcessor
     }
 
     /**
+     * Walk every resource reference in `$element` and return a message for each
+     * one that cannot be resolved against `$package`. A reference is valid when
+     * it is a `data:` URI, an `http(s)` URL, a trusted (library-provided) asset,
+     * or a file already present in the package. A relative path that is not in
+     * the package — or a path that escapes it (absolute or containing `..`) — is
+     * invalid. Read-only: unlike {@see self::process()} it resolves nothing.
+     *
+     * @return list<string>
+     */
+    public function findInvalidReferences(IXmlElement $element, QtiPackage $package): array
+    {
+        $invalid = [];
+        foreach ($element->children() as $child) {
+            if ($child instanceof IQtiResourceProvider) {
+                $message = $this->invalidReferenceMessage($child, $package);
+                if ($message !== null) {
+                    $invalid[] = $message;
+                }
+            }
+            if ($child instanceof IXmlElement) {
+                $invalid = [...$invalid, ...$this->findInvalidReferences($child, $package)];
+            }
+        }
+
+        return $invalid;
+    }
+
+    private function invalidReferenceMessage(IQtiResourceProvider $provider, QtiPackage $package): ?string
+    {
+        $source = $provider->getSource();
+        if ($source === null || $source === '' || str_starts_with($source, 'data:')) {
+            return null;
+        }
+        if ($package->hasFile($source)
+            || preg_match('~^https?://~i', $source) === 1
+            || $provider->isTrustedSource()
+        ) {
+            return null;
+        }
+
+        if (str_starts_with($source, '/') || preg_match('~(^|/)\.\.(/|$)~', $source) === 1) {
+            return sprintf('References a path outside the package: "%s"', $source);
+        }
+
+        return sprintf('References a resource that is not present in the package: "%s"', $source);
+    }
+
+    /**
      * The identifiers already taken for the run: those of the webcontent
      * gathered so far this pass plus every resource already in the source
      * package. Feeding these to the generator keeps a new media file from being

--- a/tests/Integration/PackageEditorIntegrationTest.php
+++ b/tests/Integration/PackageEditorIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Qti3\Tests\Integration;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Qti3\Package\Exception\InvalidResourceReferenceException;
 use Qti3\Package\Model\FileContent\MemoryFileContent;
 
 #[Group('integration')]
@@ -134,6 +135,37 @@ class PackageEditorIntegrationTest extends TestCase
             $reloaded->getResource('ITEM001')->resourceDependencies->all(),
         );
         $this->assertContains($resourceId, $dependencyRefs);
+    }
+
+    #[Test]
+    public function anItemUpdateReferencingAResourceNotInThePackageIsRejectedAndLeavesTheItemUntouched(): void
+    {
+        $this->seedPackageOnDisk();
+        $client = $this->createClient();
+        $editor = $client->getPackageEditor();
+
+        // The upload never happened (or the path is wrong): the item references
+        // a resource that is not in the package.
+        $package = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
+        $itemXml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<qti-assessment-item xmlns="%s" identifier="ITEM001" title="Vraag" time-dependent="false">'
+            . '<qti-item-body><p><img src="resources/never-uploaded.png" alt="Foto"/></p></qti-item-body></qti-assessment-item>',
+            self::ASI_NAMESPACE,
+        );
+        $item = $client->getAssessmentItemParser()->parseFromString($itemXml)->item;
+
+        try {
+            $editor->updateItem($package, $item);
+            $this->fail('Expected InvalidResourceReferenceException');
+        } catch (InvalidResourceReferenceException $exception) {
+            $this->assertStringContainsString('resources/never-uploaded.png', implode("\n", $exception->validationErrors()->all()));
+        }
+
+        // Nothing was written: the on-disk item still has its original content.
+        $reloaded = $client->getQtiPackageReader()->fromFilesystem(self::PACKAGE_DIR);
+        $this->assertStringContainsString('Vraag tekst', (string) $reloaded->getFile('ITEM001.xml'));
+        $this->assertStringNotContainsString('never-uploaded', (string) $reloaded->getFile('ITEM001.xml'));
     }
 
     private function seedPackageOnDisk(): void

--- a/tests/Unit/Package/Service/PackageEditorTest.php
+++ b/tests/Unit/Package/Service/PackageEditorTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Qti3\AssessmentItem\Model\AssessmentItem;
 use Qti3\AssessmentTest\Exception\InvalidAssessmentTestException;
 use Qti3\AssessmentTest\Exception\InvalidItemOrderException;
+use Qti3\Package\Exception\InvalidResourceReferenceException;
 use Qti3\Package\Filesystem\FlysystemPackageFactory;
 use Qti3\Package\Model\FileContent\MemoryFileContent;
 use Qti3\Package\Model\PackageFile\XmlFile;
@@ -418,42 +419,91 @@ final class PackageEditorTest extends TestCase
     }
 
     #[Test]
-    public function addItemRefusesLocalFilePathReferencesInItemMedia(): void
+    public function addItemRejectsAndLeavesThePackageUntouchedForADisallowedPath(): void
     {
         $package = $this->emptyDraft();
 
-        $added = $this->editor->addItemToTest($package, self::TEST_ID, $this->item('PLACEHOLDER', imageSrc: '/etc/passwd'))->resource;
-
-        $manifest = (string) $package->manifest;
-        // The local/traversal path is never registered as a resource...
-        $this->assertStringNotContainsString('passwd', $manifest);
-        // ...while the bundled (trusted) stylesheet still is.
-        $this->assertStringContainsString('type="webcontent"', $manifest);
-        $this->assertStringContainsString('.css', $manifest);
-        // The item itself was still added.
-        $this->assertSame('ITEM001', $added->identifier);
+        try {
+            $this->editor->addItemToTest($package, self::TEST_ID, $this->item('ITEM001', imageSrc: '/etc/passwd'));
+            $this->fail('Expected InvalidResourceReferenceException');
+        } catch (InvalidResourceReferenceException $exception) {
+            $this->assertStringContainsString('outside the package', implode("\n", $exception->validationErrors()->all()));
+            // The rejected edit mutated nothing: no item, no manifest entry.
+            $this->assertFalse($package->hasResource('ITEM001'));
+            $this->assertStringNotContainsString('passwd', (string) $package->manifest);
+        }
     }
 
     #[Test]
-    public function addItemSurfacesAWarningWhenItemMediaIsRefused(): void
+    public function addItemRejectsAReferenceToAResourceNotInThePackage(): void
     {
         $package = $this->emptyDraft();
 
-        // A refused reference is dropped from the package but its src stays in
-        // the item XML — the resulting data loss must reach the EditResult.
-        $result = $this->editor->addItemToTest($package, self::TEST_ID, $this->item('ITEM001', imageSrc: '/etc/passwd'));
-
-        $this->assertStringContainsString('Refused local file reference', implode("\n", $result->warnings->all()));
+        try {
+            $this->editor->addItemToTest($package, self::TEST_ID, $this->item('ITEM001', imageSrc: 'resources/missing.png'));
+            $this->fail('Expected InvalidResourceReferenceException');
+        } catch (InvalidResourceReferenceException $exception) {
+            $this->assertStringContainsString('not present in the package', implode("\n", $exception->validationErrors()->all()));
+            $this->assertStringContainsString('resources/missing.png', implode("\n", $exception->validationErrors()->all()));
+            $this->assertFalse($package->hasResource('ITEM001'));
+        }
     }
 
     #[Test]
-    public function updateItemSurfacesAWarningWhenItemMediaIsRefused(): void
+    public function updateItemRejectsAReferenceToAResourceNotInThePackageAndLeavesItUntouched(): void
+    {
+        $package = $this->draftWithMedia();
+        $before = (string) $package->getFile('ITEM001.xml');
+
+        try {
+            $this->editor->updateItem($package, $this->item('ITEM001', imageSrc: 'resources/missing.png'));
+            $this->fail('Expected InvalidResourceReferenceException');
+        } catch (InvalidResourceReferenceException) {
+            // The item content is unchanged: the failed update was not written.
+            $this->assertSame($before, (string) $package->getFile('ITEM001.xml'));
+        }
+    }
+
+    #[Test]
+    public function updateItemRejectsATraversalPath(): void
     {
         $package = $this->draftWithMedia();
 
-        $result = $this->editor->updateItem($package, $this->item('ITEM001', imageSrc: '../secret.png'));
+        $this->expectException(InvalidResourceReferenceException::class);
 
-        $this->assertStringContainsString('Refused local file reference', implode("\n", $result->warnings->all()));
+        $this->editor->updateItem($package, $this->item('ITEM001', imageSrc: '../secret.png'));
+    }
+
+    #[Test]
+    public function updateItemAcceptsAReferenceToAResourceAlreadyInThePackage(): void
+    {
+        // The media referenced by the update already lives in the package
+        // (e.g. uploaded via addResource in an earlier request): no exception.
+        $package = $this->draftWithMedia();
+
+        $result = $this->editor->updateItem($package, $this->item('ITEM001', imageSrc: 'resources/pic.png'));
+
+        $this->assertSame('ITEM001', $result->resource->identifier);
+    }
+
+    #[Test]
+    public function updateItemAcceptsADataUriReference(): void
+    {
+        $package = $this->draftWithMedia();
+
+        $result = $this->editor->updateItem($package, $this->item('ITEM001', imageSrc: 'data:image/png;base64,AAAA'));
+
+        $this->assertSame('ITEM001', $result->resource->identifier);
+    }
+
+    #[Test]
+    public function updateItemAcceptsAnHttpUrlReference(): void
+    {
+        $package = $this->draftWithMedia();
+
+        $result = $this->editor->updateItem($package, $this->item('ITEM001', imageSrc: 'https://example.com/remote.png'));
+
+        $this->assertSame('ITEM001', $result->resource->identifier);
     }
 
     #[Test]

--- a/tests/Unit/Package/Service/PackageEditorTest.php
+++ b/tests/Unit/Package/Service/PackageEditorTest.php
@@ -427,6 +427,9 @@ final class PackageEditorTest extends TestCase
             $this->editor->addItemToTest($package, self::TEST_ID, $this->item('ITEM001', imageSrc: '/etc/passwd'));
             $this->fail('Expected InvalidResourceReferenceException');
         } catch (InvalidResourceReferenceException $exception) {
+            // The top-level message covers both missing and outside-package
+            // cases; the specific reference is in the validation errors.
+            $this->assertStringContainsString('cannot be resolved against the package', $exception->getMessage());
             $this->assertStringContainsString('outside the package', implode("\n", $exception->validationErrors()->all()));
             // The rejected edit mutated nothing: no item, no manifest entry.
             $this->assertFalse($package->hasResource('ITEM001'));

--- a/tests/Unit/Package/Service/WebcontentProcessorTest.php
+++ b/tests/Unit/Package/Service/WebcontentProcessorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qti3\Tests\Unit\Package\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Qti3\Package\Downloader\Resource\IResourceDownloader;
+use Qti3\Package\Model\Manifest\Manifest;
+use Qti3\Package\Model\QtiPackage;
+use Qti3\Package\Model\Resource\ResourceCollection;
+use Qti3\Package\Service\WebcontentIdentifierGenerator;
+use Qti3\Package\Service\WebcontentProcessor;
+use Qti3\Package\Validator\Resource\IResourceValidator;
+use Qti3\Shared\Model\HTMLTag;
+use Qti3\Shared\Xml\Reader\XmlReader;
+
+final class WebcontentProcessorTest extends TestCase
+{
+    private function processor(): WebcontentProcessor
+    {
+        return new WebcontentProcessor(
+            $this->createStub(IResourceValidator::class),
+            $this->createStub(IResourceDownloader::class),
+            new WebcontentIdentifierGenerator(),
+        );
+    }
+
+    private function emptyPackage(): QtiPackage
+    {
+        $manifest = Manifest::fromString(
+            '<manifest xmlns="http://www.imsglobal.org/xsd/qti/qtiv3p0/imscp_v1p1" identifier="M"><organizations/><resources/></manifest>',
+            new XmlReader(),
+        );
+
+        return new QtiPackage(new ResourceCollection(), $manifest);
+    }
+
+    #[Test]
+    public function findInvalidReferencesValidatesTheRootElementItself(): void
+    {
+        // The root element is itself a resource provider (an <img>); its own
+        // reference must be checked, not only its descendants'.
+        $img = new HTMLTag('img', ['src' => 'resources/missing.png', 'alt' => '']);
+
+        $invalid = $this->processor()->findInvalidReferences($img, $this->emptyPackage());
+
+        $this->assertCount(1, $invalid);
+        $this->assertStringContainsString('resources/missing.png', $invalid[0]);
+    }
+
+    #[Test]
+    public function findInvalidReferencesReportsRootAndDescendantExactlyOnceEach(): void
+    {
+        // A provider root that is invalid *and* contains an invalid provider
+        // child: each is reported once — no double counting.
+        $root = new HTMLTag('img', ['src' => 'resources/root.png', 'alt' => ''], [
+            new HTMLTag('img', ['src' => 'resources/child.png', 'alt' => '']),
+        ]);
+
+        $invalid = $this->processor()->findInvalidReferences($root, $this->emptyPackage());
+
+        $this->assertCount(2, $invalid);
+        $this->assertStringContainsString('resources/root.png', implode("\n", $invalid));
+        $this->assertStringContainsString('resources/child.png', implode("\n", $invalid));
+    }
+
+    #[Test]
+    public function findInvalidReferencesAcceptsValidReferences(): void
+    {
+        // data: URI, http(s) URL and a trusted asset are all valid.
+        $root = new HTMLTag('p', [], [
+            new HTMLTag('img', ['src' => 'data:image/png;base64,AAAA', 'alt' => '']),
+            new HTMLTag('img', ['src' => 'https://example.com/x.png', 'alt' => '']),
+        ]);
+
+        $this->assertSame([], $this->processor()->findInvalidReferences($root, $this->emptyPackage()));
+    }
+}


### PR DESCRIPTION
## Summary

Completes the two-step editor flow (upload a resource, then submit item XML that references it): when an item is **added or updated**, every resource reference in its content is now validated against the package **before anything is written**, and the manifest dependencies for accepted references are reconciled (already the case, kept intact).

## Motivation

In the editor flow, request 1 stores an uploaded file in the package (`addResource`, #49) and request 2 submits the updated item XML referencing it. Previously an item referencing a resource that wasn't actually in the package (upload failed, wrong path) was saved anyway with a dangling `src` and only a soft warning. Now such an edit fails loudly.

## Behaviour

On `addItemToTest()` / `updateItem()`, each reference (`<img src>`, `<source srcset>`, …) is classified:

- **Valid** — a file already in the package (e.g. one added via `addResource`), a `data:` URI, an `http(s)` URL, or a trusted library asset.
- **Invalid** — a relative path not present in the package, or a path that escapes it (absolute, or containing `..`).

Any invalid reference throws `InvalidResourceReferenceException` (a `HasValidationErrors` domain error) listing **every** offending reference, and the edit is rejected **before any mutation**, so the package is left untouched. A path that escapes the package is reported distinctly ("outside the package") from one that is merely missing ("not present in the package").

This is a behaviour change: references that were previously refused with a warning (and saved anyway) now hard-fail. That matches the requested contract for the editor.

## Implementation

- New read-only `WebcontentProcessor::findInvalidReferences(IXmlElement, QtiPackage): list<string>` — classifies references without resolving anything, so the shared resolution path (also used by `QtiPackageBuilder`) is unaffected; only the editor's add/update hard-fail.
- New `InvalidResourceReferenceException` in `Qti3\Package\Exception` (mirrors `InvalidQtiPackageException`).
- `PackageEditor::addItemToTest()` / `updateItem()` call the check first, before any mutation.
- Orphan resources (uploaded but never referenced) are intentionally left in place — dependency handling only, no GC.

## Tests

- Unit: reject a disallowed (absolute) path and a `..` traversal; reject a relative path not in the package (add + update), asserting the package/item is untouched; accept a reference to an in-package resource, a `data:` URI and an `http(s)` URL.
- Integration: request-2 update referencing a resource that was never uploaded is rejected and the on-disk item is left unchanged (complements the existing happy-path reuse test).
- Full suite green (665 tests); phpstan green (level 0, the CI invocation).

## Docs

`docs/package-editor.md` gains a "Resource references are validated on add and update" section and the new exception in the errors table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)