### PR TITLE
Tolerate <img> without alt (default to empty alt on write)

### DIFF
--- a/docs/package-editor.md
+++ b/docs/package-editor.md
@@ -111,6 +111,11 @@ to insert it at a specific index instead:
 $editor->addItemToTest($package, $testId, $parsed->item, position: 0);
 ```
 
+> **`<img>` without `alt`.** An `<img>` may be authored without an `alt`
+> attribute — for example while the editor still lets the author fill it in.
+> Parsing accepts it, and the item is written back with a valid empty `alt=""`
+> rather than being rejected. (`src` is still required.)
+
 ## Updating an item
 
 Updating replaces the content of an existing item, identified by the model's own

--- a/src/Shared/Model/HTMLTag.php
+++ b/src/Shared/Model/HTMLTag.php
@@ -75,10 +75,13 @@ class HTMLTag implements IXmlElement, IQtiResourceProvider
             'requiredAttributes' => [],
         ],
         [
+            // `alt` is not required at construction so an <img> authored without
+            // one is accepted; a default empty alt="" is emitted on serialization
+            // (see attributes()) to keep the output valid.
             'tags' => ['img'],
             'type' => self::INLINE,
             'allowedAttributes' => ['alt', 'height', 'longdesc', 'src', 'width'],
-            'requiredAttributes' => ['alt', 'src'],
+            'requiredAttributes' => ['src'],
         ],
         [
             'tags' => ['object'],
@@ -169,6 +172,14 @@ class HTMLTag implements IXmlElement, IQtiResourceProvider
                 $attributes['src'] = $resolvedPath;
             }
         }
+
+        // `alt` is mandatory on a serialized <img>; default a missing one to the
+        // empty string (valid for a decorative image) so an item authored
+        // without alt still round-trips to spec-valid XML.
+        if ($this->tagName === 'img' && !isset($attributes['alt'])) {
+            $attributes['alt'] = '';
+        }
+
         return $attributes;
     }
 

--- a/tests/Unit/Package/Service/PackageEditorTest.php
+++ b/tests/Unit/Package/Service/PackageEditorTest.php
@@ -108,6 +108,26 @@ final class PackageEditorTest extends TestCase
     }
 
     #[Test]
+    public function addItemAcceptsAnImgWithoutAltAndStoresItWithAnEmptyAlt(): void
+    {
+        // The editor UI may submit an <img> before an alt has been filled in;
+        // it is accepted and written back with a valid empty alt="".
+        $package = $this->emptyDraft();
+
+        $xml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<qti-assessment-item xmlns="%s" identifier="PLACEHOLDER" title="Vraag" time-dependent="false">'
+            . '<qti-item-body><p><img src="data:image/png;base64,AAAA"/></p></qti-item-body></qti-assessment-item>',
+            self::ASI_NAMESPACE,
+        );
+        $item = $this->client->getAssessmentItemParser()->parseFromString($xml)->item;
+
+        $added = $this->editor->addItemToTest($package, self::TEST_ID, $item)->resource;
+
+        $this->assertStringContainsString('alt=""', (string) $package->getFile($added->href));
+    }
+
+    #[Test]
     public function addItemAppendsAnItemRefToTheSectionByDefault(): void
     {
         $package = $this->emptyDraft();

--- a/tests/Unit/Shared/Model/HTMLTagTest.php
+++ b/tests/Unit/Shared/Model/HTMLTagTest.php
@@ -180,4 +180,30 @@ class HTMLTagTest extends TestCase
 
         new HTMLTag('source', ['type' => 'image/webp']);
     }
+
+    #[Test]
+    public function anImgWithoutAltIsAcceptedAndSerializesWithAnEmptyAlt(): void
+    {
+        // Authoring an <img> without alt no longer throws; a default empty
+        // alt="" is emitted so the serialized element stays valid.
+        $tag = new HTMLTag('img', ['src' => 'resources/pic.png']);
+
+        $this->assertSame('', $tag->attributes()['alt']);
+    }
+
+    #[Test]
+    public function anImgKeepsAnExplicitAlt(): void
+    {
+        $tag = new HTMLTag('img', ['src' => 'resources/pic.png', 'alt' => 'A cat']);
+
+        $this->assertSame('A cat', $tag->attributes()['alt']);
+    }
+
+    #[Test]
+    public function anImgStillRequiresSrc(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new HTMLTag('img', ['alt' => 'A cat']);
+    }
 }


### PR DESCRIPTION
## Summary

An `<img>` without an `alt` attribute was rejected during parsing, because `HTMLTag` required `alt` at construction. In the editor flow this means an item whose image alt has not been filled in yet cannot be saved.

Per the suggested approach: **accept an `<img>` without `alt` on parse, and write a valid empty `alt=""` on serialization** — no separate enricher needed.

## Change

In `HTMLTag`:
- `alt` is removed from `<img>`'s required attributes (`src` stays required), so constructing/parsing an `<img>` without `alt` no longer throws.
- `attributes()` (the serialization source) defaults a missing `alt` to `""` for `<img>`, so the element is always written back spec-valid.

Round-trip is idempotent (`<img src=…>` → `<img src=… alt="">` → unchanged thereafter). An empty `alt` is valid for a decorative image. Scope is deliberately limited to `<img alt>`; other required attributes (e.g. `<a href>`, `<object data/type>`) are unchanged, since an empty value there is not meaningful.

## Tests

- `HTMLTag`: an `<img>` without `alt` is accepted and serializes with `alt=""`; an explicit `alt` is preserved; `src` is still required.
- Editor: adding an item whose body contains an `<img>` without `alt` succeeds and the stored item XML contains `alt=""`.
- Full suite green (664 tests); phpstan green (level 0, the CI invocation).

## Docs

`docs/package-editor.md` notes that an `<img>` without `alt` is tolerated and written back with an empty `alt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)